### PR TITLE
Protect profile endpoints with access token middleware

### DIFF
--- a/user-services/internal/api/controllers/profile_controller.go
+++ b/user-services/internal/api/controllers/profile_controller.go
@@ -1,9 +1,16 @@
 package controllers
 
 import (
+	"errors"
+	"net/http"
+
+	"user-services/internal/api/dto"
+	"user-services/internal/api/middleware"
 	"user-services/internal/api/services"
+	"user-services/internal/utils"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 )
 
 type ProfileController struct {
@@ -23,7 +30,30 @@ func NewProfileController(profileService services.UserProfileService) *ProfileCo
 // @Success 200 {object} dto.UserProfile
 // @Router /profile [get]
 func (c *ProfileController) GetProfile(ctx *gin.Context) {
-	// TODO: implement
+	userIDValue, exists := ctx.Get(middleware.ContextUserIDKey())
+	if !exists {
+		utils.Fail(ctx, "Unauthorized", http.StatusUnauthorized, nil)
+		return
+	}
+
+	userID, ok := userIDValue.(uuid.UUID)
+	if !ok {
+		utils.Fail(ctx, "Unauthorized", http.StatusUnauthorized, "invalid user context")
+		return
+	}
+
+	profile, err := c.profileService.GetProfile(ctx.Request.Context(), userID)
+	if err != nil {
+		if errors.Is(err, services.ErrProfileNotFound) {
+			utils.Fail(ctx, "Profile not found", http.StatusNotFound, nil)
+			return
+		}
+
+		utils.Fail(ctx, "Failed to retrieve profile", http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	utils.Success(ctx, profile)
 }
 
 // UpdateProfile godoc
@@ -35,5 +65,39 @@ func (c *ProfileController) GetProfile(ctx *gin.Context) {
 // @Success 200 {object} dto.UserProfile
 // @Router /profile [put]
 func (c *ProfileController) UpdateProfile(ctx *gin.Context) {
-	// TODO: implement
+	userIDValue, exists := ctx.Get(middleware.ContextUserIDKey())
+	if !exists {
+		utils.Fail(ctx, "Unauthorized", http.StatusUnauthorized, nil)
+		return
+	}
+
+	userID, ok := userIDValue.(uuid.UUID)
+	if !ok {
+		utils.Fail(ctx, "Unauthorized", http.StatusUnauthorized, "invalid user context")
+		return
+	}
+
+	var req dto.UpdateProfileRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		utils.Fail(ctx, "Invalid request data", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := c.profileService.UpdateProfile(ctx.Request.Context(), userID, &req); err != nil {
+		if errors.Is(err, services.ErrProfileNotFound) {
+			utils.Fail(ctx, "Profile not found", http.StatusNotFound, nil)
+			return
+		}
+
+		utils.Fail(ctx, "Failed to update profile", http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	profile, err := c.profileService.GetProfile(ctx.Request.Context(), userID)
+	if err != nil {
+		utils.Fail(ctx, "Failed to retrieve profile", http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	utils.Success(ctx, profile)
 }

--- a/user-services/internal/api/middleware/auth_middleware.go
+++ b/user-services/internal/api/middleware/auth_middleware.go
@@ -1,0 +1,56 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"user-services/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	contextUserIDKey    = "userID"
+	contextUserEmailKey = "userEmail"
+)
+
+// AuthRequired ensures requests include a valid Bearer access token.
+func AuthRequired() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			utils.Fail(c, "Unauthorized", http.StatusUnauthorized, "missing authorization header")
+			c.Abort()
+			return
+		}
+
+		parts := strings.SplitN(authHeader, " ", 2)
+		if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+			utils.Fail(c, "Unauthorized", http.StatusUnauthorized, "invalid authorization header format")
+			c.Abort()
+			return
+		}
+
+		claims, err := utils.ValidateJWT(strings.TrimSpace(parts[1]))
+		if err != nil {
+			utils.Fail(c, "Unauthorized", http.StatusUnauthorized, err.Error())
+			c.Abort()
+			return
+		}
+
+		c.Set(contextUserIDKey, claims.UserID)
+		c.Set(contextUserEmailKey, claims.Email)
+
+		c.Next()
+	}
+}
+
+// ContextUserIDKey exposes the context key used to store the authenticated user ID.
+func ContextUserIDKey() string {
+	return contextUserIDKey
+}
+
+// ContextUserEmailKey exposes the context key used to store the authenticated user email.
+func ContextUserEmailKey() string {
+	return contextUserEmailKey
+}

--- a/user-services/internal/api/repositories/user_profile_repo.go
+++ b/user-services/internal/api/repositories/user_profile_repo.go
@@ -28,13 +28,15 @@ func (r *userProfileRepository) Create(ctx context.Context, profile *models.User
 }
 
 func (r *userProfileRepository) GetByUserID(ctx context.Context, userID uuid.UUID) (*models.UserProfile, error) {
-	// TODO: implement
-	return nil, nil
+	var profile models.UserProfile
+	if err := r.db.WithContext(ctx).Where("user_id = ?", userID).First(&profile).Error; err != nil {
+		return nil, err
+	}
+	return &profile, nil
 }
 
 func (r *userProfileRepository) Update(ctx context.Context, profile *models.UserProfile) error {
-	// TODO: implement
-	return nil
+	return r.db.WithContext(ctx).Save(profile).Error
 }
 
 func (r *userProfileRepository) Delete(ctx context.Context, userID uuid.UUID) error {

--- a/user-services/internal/api/routes/profile_routes.go
+++ b/user-services/internal/api/routes/profile_routes.go
@@ -2,12 +2,14 @@ package routes
 
 import (
 	"user-services/internal/api/controllers"
+	"user-services/internal/api/middleware"
 
 	"github.com/gin-gonic/gin"
 )
 
 func RegisterProfileRoutes(router *gin.RouterGroup, controller *controllers.ProfileController) {
 	profile := router.Group("/profile")
+	profile.Use(middleware.AuthRequired())
 	{
 		profile.GET("", controller.GetProfile)    // GET /profile
 		profile.PUT("", controller.UpdateProfile) // PUT /profile

--- a/user-services/internal/server/router.go
+++ b/user-services/internal/server/router.go
@@ -34,13 +34,16 @@ func NewRouter(deps Deps) *gin.Engine {
 	loginAttemptRepo := repositories.NewLoginAttemptRepository(deps.DB)
 	// Initialize services
 	authService := services.NewAuthService(userRepo, userProfileRepo, auditLogRepo, outboxRepo, sessionRepo, refreshTokenRepo, mfaRepo, loginAttemptRepo)
+	profileService := services.NewUserProfileService(userProfileRepo)
 
 	// Initialize controllers
 	authCtrl := controllers.NewAuthController(authService)
+	profileCtrl := controllers.NewProfileController(profileService)
 
 	api := r.Group("/api/v1")
 	{
 		routers.RegisterAuthRoutes(api, *authCtrl)
+		routers.RegisterProfileRoutes(api, profileCtrl)
 	}
 
 	return r


### PR DESCRIPTION
## Summary
- add an authentication middleware that validates Bearer access tokens and injects user context
- require the middleware on the profile route group so only authenticated callers can access it
- update profile controllers to read the authenticated user ID from context instead of headers and expose JWT validation helpers

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68dcf9580ee0832ab71a58d64ab3a5fe