### PR TITLE
Implement password reset service logic

### DIFF
--- a/user-services/internal/api/controllers/password_controller.go
+++ b/user-services/internal/api/controllers/password_controller.go
@@ -1,9 +1,16 @@
 package controllers
 
 import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"user-services/internal/api/dto"
 	"user-services/internal/api/services"
+	"user-services/internal/utils"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 )
 
 type PasswordController struct {
@@ -24,7 +31,29 @@ func NewPasswordController(passwordService services.PasswordService) *PasswordCo
 // @Success 200
 // @Router /password/reset/request [post]
 func (c *PasswordController) RequestPasswordReset(ctx *gin.Context) {
-	// TODO: implement
+	var req dto.PasswordResetRequestDTO
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		utils.Fail(ctx, "Invalid request data", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	email := strings.TrimSpace(strings.ToLower(req.Email))
+	if email == "" {
+		utils.Fail(ctx, "Email is required", http.StatusBadRequest, nil)
+		return
+	}
+
+	if err := c.passwordService.InitiatePasswordReset(ctx.Request.Context(), email); err != nil {
+		switch {
+		case errors.Is(err, utils.ErrEmailRequired), errors.Is(err, utils.ErrInvalidEmail):
+			utils.Fail(ctx, "Invalid email address", http.StatusBadRequest, err.Error())
+		default:
+			utils.Fail(ctx, "Failed to initiate password reset", http.StatusInternalServerError, err.Error())
+		}
+		return
+	}
+
+	utils.Success(ctx, gin.H{"message": "Password reset request received"})
 }
 
 // ConfirmPasswordReset godoc
@@ -35,7 +64,30 @@ func (c *PasswordController) RequestPasswordReset(ctx *gin.Context) {
 // @Success 200
 // @Router /password/reset/confirm [post]
 func (c *PasswordController) ConfirmPasswordReset(ctx *gin.Context) {
-	// TODO: implement
+	var req dto.PasswordResetConfirmDTO
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		utils.Fail(ctx, "Invalid request data", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if strings.TrimSpace(req.Token) == "" || strings.TrimSpace(req.NewPassword) == "" {
+		utils.Fail(ctx, "Token and new password are required", http.StatusBadRequest, nil)
+		return
+	}
+
+	if err := c.passwordService.CompletePasswordReset(ctx.Request.Context(), strings.TrimSpace(req.Token), req.NewPassword); err != nil {
+		switch {
+		case errors.Is(err, services.ErrResetTokenInvalid):
+			utils.Fail(ctx, "Invalid or expired reset token", http.StatusBadRequest, err.Error())
+		case errors.Is(err, utils.ErrWeakPassword), errors.Is(err, utils.ErrPasswordRequired):
+			utils.Fail(ctx, "New password does not meet requirements", http.StatusBadRequest, err.Error())
+		default:
+			utils.Fail(ctx, "Failed to reset password", http.StatusInternalServerError, err.Error())
+		}
+		return
+	}
+
+	utils.Success(ctx, gin.H{"message": "Password has been reset"})
 }
 
 // ChangePassword godoc
@@ -46,5 +98,50 @@ func (c *PasswordController) ConfirmPasswordReset(ctx *gin.Context) {
 // @Success 200
 // @Router /password/change [post]
 func (c *PasswordController) ChangePassword(ctx *gin.Context) {
-	// TODO: implement
+	var req dto.ChangePasswordRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		utils.Fail(ctx, "Invalid request data", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if strings.TrimSpace(req.OldPassword) == "" || strings.TrimSpace(req.NewPassword) == "" {
+		utils.Fail(ctx, "Current and new password are required", http.StatusBadRequest, nil)
+		return
+	}
+
+	userIDValue, exists := ctx.Get("userID")
+	if !exists {
+		utils.Fail(ctx, "User not authenticated", http.StatusUnauthorized, nil)
+		return
+	}
+
+	var userID uuid.UUID
+	switch v := userIDValue.(type) {
+	case uuid.UUID:
+		userID = v
+	case string:
+		parsed, err := uuid.Parse(v)
+		if err != nil {
+			utils.Fail(ctx, "Invalid user identifier", http.StatusUnauthorized, err.Error())
+			return
+		}
+		userID = parsed
+	default:
+		utils.Fail(ctx, "Invalid user identifier", http.StatusUnauthorized, nil)
+		return
+	}
+
+	if err := c.passwordService.ChangePassword(ctx.Request.Context(), userID, req.OldPassword, req.NewPassword); err != nil {
+		switch {
+		case errors.Is(err, services.ErrPasswordMismatch):
+			utils.Fail(ctx, "Current password is incorrect", http.StatusBadRequest, err.Error())
+		case errors.Is(err, utils.ErrWeakPassword), errors.Is(err, utils.ErrPasswordRequired):
+			utils.Fail(ctx, "New password does not meet requirements", http.StatusBadRequest, err.Error())
+		default:
+			utils.Fail(ctx, "Failed to change password", http.StatusInternalServerError, err.Error())
+		}
+		return
+	}
+
+	utils.Success(ctx, gin.H{"message": "Password changed successfully"})
 }

--- a/user-services/internal/api/dto/auth_dto.go
+++ b/user-services/internal/api/dto/auth_dto.go
@@ -46,23 +46,6 @@ type LogoutRequest struct {
 	SessionID string `json:"session_id,omitempty"`
 }
 
-// PasswordResetRequestDTO initiates password reset
-type PasswordResetRequestDTO struct {
-	Email string `json:"email" binding:"required,email"`
-}
-
-// PasswordResetConfirmDTO completes password reset
-type PasswordResetConfirmDTO struct {
-	Token       string `json:"token" binding:"required"`
-	NewPassword string `json:"new_password" binding:"required,min=8"`
-}
-
-// ChangePasswordRequest for authenticated users
-type ChangePasswordRequest struct {
-	OldPassword string `json:"old_password" binding:"required"`
-	NewPassword string `json:"new_password" binding:"required,min=8"`
-}
-
 // VerifyEmailRequest to verify email address
 type VerifyEmailRequest struct {
 	Token string `json:"token" binding:"required"`

--- a/user-services/internal/api/dto/password_dto.go
+++ b/user-services/internal/api/dto/password_dto.go
@@ -1,0 +1,18 @@
+package dto
+
+// PasswordResetRequestDTO initiates password reset
+type PasswordResetRequestDTO struct {
+	Email string `json:"email" binding:"required,email"`
+}
+
+// PasswordResetConfirmDTO completes password reset
+type PasswordResetConfirmDTO struct {
+	Token       string `json:"token" binding:"required"`
+	NewPassword string `json:"new_password" binding:"required,min=8"`
+}
+
+// ChangePasswordRequest for authenticated users
+type ChangePasswordRequest struct {
+	OldPassword string `json:"old_password" binding:"required"`
+	NewPassword string `json:"new_password" binding:"required,min=8"`
+}

--- a/user-services/internal/api/repositories/password_reset_repo.go
+++ b/user-services/internal/api/repositories/password_reset_repo.go
@@ -25,26 +25,34 @@ func NewPasswordResetRepository(db *gorm.DB) PasswordResetRepository {
 }
 
 func (r *passwordResetRepository) Create(ctx context.Context, reset *models.PasswordReset) error {
-	// TODO: implement
-	return nil
+	return r.db.WithContext(ctx).Create(reset).Error
 }
 
 func (r *passwordResetRepository) GetByTokenHash(ctx context.Context, tokenHash string) (*models.PasswordReset, error) {
-	// TODO: implement
-	return nil, nil
+	var reset models.PasswordReset
+	if err := r.db.WithContext(ctx).Where("token_hash = ?", tokenHash).First(&reset).Error; err != nil {
+		return nil, err
+	}
+	return &reset, nil
 }
 
 func (r *passwordResetRepository) Consume(ctx context.Context, id uuid.UUID) error {
-	// TODO: implement
-	return nil
+	return r.db.WithContext(ctx).
+		Model(&models.PasswordReset{}).
+		Where("id = ? AND consumed_at IS NULL", id).
+		Update("consumed_at", gorm.Expr("now()")).Error
 }
 
 func (r *passwordResetRepository) DeleteExpired(ctx context.Context) error {
-	// TODO: implement
-	return nil
+	return r.db.WithContext(ctx).
+		Where("expires_at < now()").
+		Delete(&models.PasswordReset{}).
+		Error
 }
 
 func (r *passwordResetRepository) DeleteByUserID(ctx context.Context, userID uuid.UUID) error {
-	// TODO: implement
-	return nil
+	return r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Delete(&models.PasswordReset{}).
+		Error
 }

--- a/user-services/internal/api/repositories/user_repo.go
+++ b/user-services/internal/api/repositories/user_repo.go
@@ -9,6 +9,8 @@ import (
 	"gorm.io/gorm"
 )
 
+var ErrUserNotFound = errors.New("user not found")
+
 type UserRepository struct {
 	DB *gorm.DB
 }
@@ -50,7 +52,7 @@ func (r *UserRepository) GetUserByEmail(ctx context.Context, email string) (mode
 	err := r.DB.WithContext(ctx).Preload("Profile").First(&user, "email = ?", email).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return models.User{}, errors.New("user not found")
+			return models.User{}, ErrUserNotFound
 		}
 		return models.User{}, err
 	}
@@ -60,10 +62,13 @@ func (r *UserRepository) GetUserByEmail(ctx context.Context, email string) (mode
 // GetUserByID retrieves a user by their ID
 func (r *UserRepository) GetUserByID(ctx context.Context, userID string) (models.User, error) {
 	var user models.User
-	err := r.DB.WithContext(ctx).Where("id = ?", userID).First(&user).Preload("Profile").Error
+	err := r.DB.WithContext(ctx).
+		Preload("Profile").
+		Where("id = ?", userID).
+		First(&user).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return models.User{}, errors.New("user not found")
+			return models.User{}, ErrUserNotFound
 		}
 		return models.User{}, err
 	}

--- a/user-services/internal/api/services/password_service.go
+++ b/user-services/internal/api/services/password_service.go
@@ -2,9 +2,31 @@ package services
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
 	"user-services/internal/api/repositories"
+	"user-services/internal/config"
+	"user-services/internal/models"
+	"user-services/internal/utils"
 
 	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const defaultResetTokenTTL = time.Hour
+
+var (
+	// ErrResetTokenInvalid indicates the reset token is missing, consumed, or expired.
+	ErrResetTokenInvalid = errors.New("invalid or expired password reset token")
+	// ErrPasswordMismatch indicates the provided current password is incorrect.
+	ErrPasswordMismatch = errors.New("current password is incorrect")
 )
 
 type PasswordService interface {
@@ -16,44 +38,248 @@ type PasswordService interface {
 }
 
 type passwordService struct {
-	userRepo          repositories.UserRepository
+	userRepo          *repositories.UserRepository
 	passwordResetRepo repositories.PasswordResetRepository
 	auditLogRepo      repositories.AuditLogRepository
+	outboxRepo        repositories.OutboxRepository
+	resetTTL          time.Duration
 }
 
 func NewPasswordService(
-	userRepo repositories.UserRepository,
+	userRepo *repositories.UserRepository,
 	passwordResetRepo repositories.PasswordResetRepository,
 	auditLogRepo repositories.AuditLogRepository,
+	outboxRepo repositories.OutboxRepository,
 ) PasswordService {
 	return &passwordService{
 		userRepo:          userRepo,
 		passwordResetRepo: passwordResetRepo,
 		auditLogRepo:      auditLogRepo,
+		outboxRepo:        outboxRepo,
+		resetTTL:          defaultResetTokenTTL,
 	}
 }
 
 func (s *passwordService) InitiatePasswordReset(ctx context.Context, email string) error {
-	// TODO: implement - generate token, save to DB, send email
+	normalizedEmail := strings.TrimSpace(strings.ToLower(email))
+	if err := utils.ValidateEmail(normalizedEmail); err != nil {
+		return err
+	}
+
+	user, err := s.userRepo.GetUserByEmail(ctx, normalizedEmail)
+	if err != nil {
+		if errors.Is(err, repositories.ErrUserNotFound) || errors.Is(err, gorm.ErrRecordNotFound) {
+			// Avoid user enumeration by returning success even if the email is unknown.
+			return nil
+		}
+		return err
+	}
+
+	if err := s.passwordResetRepo.DeleteByUserID(ctx, user.ID); err != nil {
+		return err
+	}
+
+	rawToken, tokenHash, err := generateResetToken()
+	if err != nil {
+		return err
+	}
+
+	reset := &models.PasswordReset{
+		UserID:    user.ID,
+		TokenHash: tokenHash,
+		ExpiresAt: time.Now().Add(s.resetTTL),
+	}
+	if err := s.passwordResetRepo.Create(ctx, reset); err != nil {
+		return err
+	}
+
+	s.recordAudit(ctx, user.ID, "user.password_reset.requested", map[string]any{
+		"email": user.Email,
+	})
+
+	if s.outboxRepo != nil {
+		if err := s.enqueuePasswordResetEmail(ctx, user, rawToken); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
 func (s *passwordService) VerifyResetToken(ctx context.Context, token string) (*uuid.UUID, error) {
-	// TODO: implement - verify token and return user ID
-	return nil, nil
+	reset, err := s.getActiveReset(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	return &reset.UserID, nil
 }
 
 func (s *passwordService) CompletePasswordReset(ctx context.Context, token, newPassword string) error {
-	// TODO: implement - verify token, update password, consume token
+	if err := utils.ValidatePassword(newPassword); err != nil {
+		return err
+	}
+
+	reset, err := s.getActiveReset(ctx, token)
+	if err != nil {
+		return err
+	}
+
+	user, err := s.userRepo.GetUserByID(ctx, reset.UserID.String())
+	if err != nil {
+		if errors.Is(err, repositories.ErrUserNotFound) || errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrResetTokenInvalid
+		}
+		return err
+	}
+
+	hash, err := utils.HashPassword(newPassword)
+	if err != nil {
+		return err
+	}
+
+	user.PasswordHash = hash
+	if err := s.userRepo.UpdateUser(ctx, &user); err != nil {
+		return err
+	}
+
+	if err := s.passwordResetRepo.Consume(ctx, reset.ID); err != nil {
+		return err
+	}
+
+	if err := s.passwordResetRepo.DeleteByUserID(ctx, reset.UserID); err != nil {
+		return err
+	}
+
+	s.recordAudit(ctx, user.ID, "user.password_reset.completed", map[string]any{
+		"reset_id": reset.ID.String(),
+	})
+
 	return nil
 }
 
 func (s *passwordService) ChangePassword(ctx context.Context, userID uuid.UUID, oldPassword, newPassword string) error {
-	// TODO: implement - verify old password, update to new
+	if err := utils.ValidatePassword(newPassword); err != nil {
+		return err
+	}
+
+	user, err := s.userRepo.GetUserByID(ctx, userID.String())
+	if err != nil {
+		return err
+	}
+
+	if err := utils.CheckPassword(user.PasswordHash, oldPassword); err != nil {
+		return ErrPasswordMismatch
+	}
+
+	hash, err := utils.HashPassword(newPassword)
+	if err != nil {
+		return err
+	}
+
+	user.PasswordHash = hash
+	if err := s.userRepo.UpdateUser(ctx, &user); err != nil {
+		return err
+	}
+
+	if err := s.passwordResetRepo.DeleteByUserID(ctx, userID); err != nil {
+		return err
+	}
+
+	s.recordAudit(ctx, user.ID, "user.password.changed", map[string]any{
+		"initiator": "self",
+	})
+
 	return nil
 }
 
 func (s *passwordService) CleanupExpiredResets(ctx context.Context) error {
-	// TODO: implement
-	return nil
+	return s.passwordResetRepo.DeleteExpired(ctx)
+}
+
+func (s *passwordService) getActiveReset(ctx context.Context, token string) (*models.PasswordReset, error) {
+	trimmed := strings.TrimSpace(token)
+	if trimmed == "" {
+		return nil, ErrResetTokenInvalid
+	}
+
+	tokenHash := hashToken(trimmed)
+	reset, err := s.passwordResetRepo.GetByTokenHash(ctx, tokenHash)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrResetTokenInvalid
+		}
+		return nil, err
+	}
+
+	if reset.ConsumedAt.Valid {
+		return nil, ErrResetTokenInvalid
+	}
+
+	if time.Now().After(reset.ExpiresAt) {
+		return nil, ErrResetTokenInvalid
+	}
+
+	return reset, nil
+}
+
+func (s *passwordService) recordAudit(ctx context.Context, userID uuid.UUID, action string, metadata map[string]any) {
+	if s.auditLogRepo == nil {
+		return
+	}
+
+	audit := &models.AuditLog{
+		UserID:    &userID,
+		ActorID:   &userID,
+		Action:    action,
+		Metadata:  metadata,
+		CreatedAt: time.Now(),
+	}
+
+	_ = s.auditLogRepo.Create(ctx, audit)
+}
+
+func (s *passwordService) enqueuePasswordResetEmail(ctx context.Context, user models.User, token string) error {
+	resetURL := buildPasswordResetURL(token)
+
+	event := &models.Outbox{
+		AggregateID: user.ID,
+		Topic:       "user.events",
+		Type:        "user.password_reset",
+		Payload: map[string]any{
+			"user_id":            user.ID.String(),
+			"email":              user.Email,
+			"reset_link":         resetURL,
+			"reset_token":        token,
+			"expires_in_minutes": int(s.resetTTL / time.Minute),
+			"appName":            config.GetAppName(),
+			"supportEmail":       config.GetSupportEmail(),
+		},
+		CreatedAt: time.Now(),
+	}
+
+	return s.outboxRepo.Create(ctx, event)
+}
+
+func generateResetToken() (string, string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", "", err
+	}
+
+	raw := base64.RawURLEncoding.EncodeToString(buf)
+	return raw, hashToken(raw), nil
+}
+
+func hashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+func buildPasswordResetURL(token string) string {
+	base := strings.TrimRight(config.GetPublicAppURL(), "/")
+	path := strings.TrimLeft(config.GetPasswordResetPath(), "/")
+	if path == "" {
+		return fmt.Sprintf("%s?token=%s", base, token)
+	}
+	return fmt.Sprintf("%s/%s?token=%s", base, path, token)
 }

--- a/user-services/internal/config/config.go
+++ b/user-services/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strings"
 
 	"github.com/joho/godotenv"
 )
@@ -19,4 +20,27 @@ func GetPort() string {
 		return p
 	}
 	return "8001"
+}
+
+func GetAppName() string {
+	return getEnv("APP_NAME", "Microservice App")
+}
+
+func GetSupportEmail() string {
+	return getEnv("SUPPORT_EMAIL", "support@example.com")
+}
+
+func GetPublicAppURL() string {
+	return getEnv("PUBLIC_APP_URL", "http://localhost:3000")
+}
+
+func GetPasswordResetPath() string {
+	return getEnv("PASSWORD_RESET_PATH", "/reset-password")
+}
+
+func getEnv(key, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return fallback
 }


### PR DESCRIPTION
## Summary
- add dedicated password DTO definitions for reset and change flows
- implement password reset repository methods and expose a reusable user-not-found error
- build out the password service with token generation, audit/outbox integration, and improved controller responses
- provide configuration helpers for composing password reset emails

## Testing
- `go test ./...` *(hangs in this environment, aborted after waiting)*

------
https://chatgpt.com/codex/tasks/task_b_68dcf92bda74832aa154f1340c576c3a