### PR TITLE
Implement session management API

### DIFF
--- a/user-services/internal/api/routes/session_routes.go
+++ b/user-services/internal/api/routes/session_routes.go
@@ -2,12 +2,14 @@ package routes
 
 import (
 	"user-services/internal/api/controllers"
+	"user-services/internal/api/middleware"
 
 	"github.com/gin-gonic/gin"
 )
 
 func RegisterSessionRoutes(router *gin.RouterGroup, controller *controllers.SessionController) {
 	sessions := router.Group("/sessions")
+	sessions.Use(middleware.AuthRequired())
 	{
 		sessions.GET("", controller.GetActiveSessions)             // GET /sessions
 		sessions.DELETE("/:id", controller.RevokeSession)          // DELETE /sessions/:id

--- a/user-services/internal/server/router.go
+++ b/user-services/internal/server/router.go
@@ -38,17 +38,20 @@ func NewRouter(deps Deps) *gin.Engine {
 	authService := services.NewAuthService(userRepo, userProfileRepo, auditLogRepo, outboxRepo, sessionRepo, refreshTokenRepo, mfaRepo, loginAttemptRepo)
 	profileService := services.NewUserProfileService(userProfileRepo)
 	passwordService := services.NewPasswordService(userRepo, passwordResetRepo, auditLogRepo, outboxRepo, userProfileRepo)
+	sessionService := services.NewSessionService(sessionRepo)
 
 	// Initialize controllers
 	authCtrl := controllers.NewAuthController(authService)
 	profileCtrl := controllers.NewProfileController(profileService)
 	passwordCtrl := controllers.NewPasswordController(passwordService)
+	sessionCtrl := controllers.NewSessionController(sessionService)
 
 	api := r.Group("/api/v1")
 	{
 		routers.RegisterAuthRoutes(api, *authCtrl)
 		routers.RegisterProfileRoutes(api, profileCtrl)
 		routers.RegisterPasswordRoutes(api, passwordCtrl)
+		routers.RegisterSessionRoutes(api, sessionCtrl)
 	}
 
 	return r


### PR DESCRIPTION
## Summary
- add repository and service logic for managing session lifecycle operations
- expose authenticated session controller endpoints and register them on the API router

## Testing
- `go test ./...` *(fails: command hung in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dde7b8a1e0832a9e96e909e82134ab