### PR TITLE
Add user auth integration to BFF

### DIFF
--- a/bff-services/cmd/server/main.go
+++ b/bff-services/cmd/server/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bff-services/internal/config"
 	"bff-services/internal/server"
+	"bff-services/internal/services"
+	"bff-services/internal/utils"
 	"context"
 	"log"
 	"os"
@@ -17,15 +19,18 @@ func main() {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 
+	userServiceURL := utils.GetEnv("USER_SERVICE_URL", "http://localhost:8001")
+	userService := services.NewUserServiceClient(userServiceURL, nil)
 
 	addr := ":" + port
 	log.Printf("Starting server on %s", addr)
 	if err := server.NewRouter(server.Deps{
+		UserService: userService,
 	}).Run(addr); err != nil {
 		log.Printf("Server error: %v", err)
 		os.Exit(1)
 	}
-	
+
 	_, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	// Wait for interrupt signal

--- a/bff-services/internal/api/controllers/auth_controller.go
+++ b/bff-services/internal/api/controllers/auth_controller.go
@@ -1,0 +1,65 @@
+package controllers
+
+import (
+	"net/http"
+
+	"bff-services/internal/api/dto"
+	"bff-services/internal/services"
+	"bff-services/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+type AuthController struct {
+	userService services.UserService
+}
+
+func NewAuthController(userService services.UserService) *AuthController {
+	return &AuthController{userService: userService}
+}
+
+func (a *AuthController) Register(c *gin.Context) {
+	var req dto.RegisterRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.Fail(c, "Invalid request data", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := a.userService.Register(c.Request.Context(), req)
+	if err != nil {
+		utils.Fail(c, "Unable to register user", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithEnvelope(c, resp)
+}
+
+func (a *AuthController) Login(c *gin.Context) {
+	var req dto.LoginRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.Fail(c, "Invalid request data", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := a.userService.Login(c.Request.Context(), req, c.GetHeader("User-Agent"), c.ClientIP())
+	if err != nil {
+		utils.Fail(c, "Unable to login", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithEnvelope(c, resp)
+}
+
+func respondWithEnvelope(c *gin.Context, resp *services.HTTPResponse) {
+	if resp == nil {
+		c.Status(http.StatusNoContent)
+		return
+	}
+
+	if resp.IsBodyEmpty() {
+		c.Status(resp.StatusCode)
+		return
+	}
+
+	c.JSON(resp.StatusCode, resp.Body)
+}

--- a/bff-services/internal/api/dto/auth_dto.go
+++ b/bff-services/internal/api/dto/auth_dto.go
@@ -1,0 +1,15 @@
+package dto
+
+// RegisterRequest represents payload for user registration via the BFF.
+type RegisterRequest struct {
+	Email    string `json:"email" binding:"required,email"`
+	Name     string `json:"name" binding:"required"`
+	Password string `json:"password" binding:"required,min=8"`
+}
+
+// LoginRequest represents payload for user login via the BFF.
+type LoginRequest struct {
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required"`
+	MFACode  string `json:"mfa_code,omitempty"`
+}

--- a/bff-services/internal/server/router.go
+++ b/bff-services/internal/server/router.go
@@ -2,12 +2,13 @@ package server
 
 import (
 	"bff-services/internal/api/controllers"
+	"bff-services/internal/services"
 
 	"github.com/gin-gonic/gin"
 )
 
 type Deps struct {
-	// RedisClient *redis.Client
+	UserService services.UserService
 }
 
 func NewRouter(deps Deps) *gin.Engine {
@@ -19,10 +20,18 @@ func NewRouter(deps Deps) *gin.Engine {
 
 	r.GET("/health", controllers.Health)
 
+	var authCtrl *controllers.AuthController
+	if deps.UserService != nil {
+		authCtrl = controllers.NewAuthController(deps.UserService)
+	}
 
 	api := r.Group("/api/v1")
 	{
 		api.GET("/health", controllers.Health)
+		if authCtrl != nil {
+			api.POST("/user/register", authCtrl.Register)
+			api.POST("/user/login", authCtrl.Login)
+		}
 	}
 
 	return r

--- a/bff-services/internal/services/user_service.go
+++ b/bff-services/internal/services/user_service.go
@@ -1,0 +1,114 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"bff-services/internal/api/dto"
+)
+
+type UserService interface {
+	Register(ctx context.Context, payload dto.RegisterRequest) (*HTTPResponse, error)
+	Login(ctx context.Context, payload dto.LoginRequest, userAgent, clientIP string) (*HTTPResponse, error)
+}
+
+type UserServiceClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+type HTTPResponse struct {
+	StatusCode int
+	Body       Envelope
+}
+
+type Envelope struct {
+	Status  string          `json:"status"`
+	Message string          `json:"message,omitempty"`
+	Data    json.RawMessage `json:"data,omitempty"`
+	Error   json.RawMessage `json:"error,omitempty"`
+}
+
+func NewUserServiceClient(baseURL string, httpClient *http.Client) *UserServiceClient {
+	trimmed := strings.TrimRight(baseURL, "/")
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &UserServiceClient{
+		baseURL:    trimmed,
+		httpClient: httpClient,
+	}
+}
+
+func (c *UserServiceClient) Register(ctx context.Context, payload dto.RegisterRequest) (*HTTPResponse, error) {
+	return c.doPost(ctx, "/api/v1/register", payload, nil)
+}
+
+func (c *UserServiceClient) Login(ctx context.Context, payload dto.LoginRequest, userAgent, clientIP string) (*HTTPResponse, error) {
+	headers := http.Header{}
+	if userAgent != "" {
+		headers.Set("User-Agent", userAgent)
+	}
+	if clientIP != "" {
+		headers.Set("X-Forwarded-For", clientIP)
+	}
+	return c.doPost(ctx, "/api/v1/login", payload, headers)
+}
+
+func (c *UserServiceClient) doPost(ctx context.Context, path string, payload interface{}, headers http.Header) (*HTTPResponse, error) {
+	if c.baseURL == "" {
+		return nil, fmt.Errorf("user service base URL is not configured")
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal payload: %w", err)
+	}
+
+	endpoint := c.baseURL + path
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	for key, values := range headers {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("perform request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	var envelope Envelope
+	if len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, &envelope); err != nil {
+			return nil, fmt.Errorf("decode response: %w", err)
+		}
+	}
+
+	return &HTTPResponse{
+		StatusCode: resp.StatusCode,
+		Body:       envelope,
+	}, nil
+}
+
+func (r HTTPResponse) IsBodyEmpty() bool {
+	return r.Body.Status == "" && r.Body.Message == "" && len(r.Body.Data) == 0 && len(r.Body.Error) == 0
+}


### PR DESCRIPTION
## Summary
- add a user auth controller with login and register handlers for the BFF
- create an HTTP client for the user service and expose configuration via USER_SERVICE_URL
- wire the new client into the router so /api/v1/user/login and /api/v1/user/register proxy to the user service

## Testing
- go test ./... *(fails: command hung waiting for module build, aborted)*

------
https://chatgpt.com/codex/tasks/task_b_68df90403488832abea6c322462db638