### PR TITLE
Add user API proxy support to BFF service

### DIFF
--- a/bff-services/internal/api/controllers/helpers.go
+++ b/bff-services/internal/api/controllers/helpers.go
@@ -1,0 +1,28 @@
+package controllers
+
+import (
+	"net/http"
+	"strings"
+
+	"bff-services/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// requireBearerToken extracts the bearer token from the Authorization header.
+// It returns false and writes an error response if the token is missing or malformed.
+func requireBearerToken(c *gin.Context) (string, bool) {
+	header := c.GetHeader("Authorization")
+	if header == "" {
+		utils.Fail(c, "Authorization token is required", http.StatusUnauthorized, "missing authorization header")
+		return "", false
+	}
+
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") || strings.TrimSpace(parts[1]) == "" {
+		utils.Fail(c, "Invalid authorization header", http.StatusUnauthorized, "invalid bearer token")
+		return "", false
+	}
+
+	return strings.TrimSpace(parts[1]), true
+}

--- a/bff-services/internal/api/controllers/mfa_controller.go
+++ b/bff-services/internal/api/controllers/mfa_controller.go
@@ -1,0 +1,97 @@
+package controllers
+
+import (
+	"net/http"
+
+	"bff-services/internal/api/dto"
+	"bff-services/internal/services"
+	"bff-services/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+type MFAController struct {
+	userService services.UserService
+}
+
+func NewMFAController(userService services.UserService) *MFAController {
+	return &MFAController{userService: userService}
+}
+
+func (m *MFAController) Setup(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	var req dto.MFASetupRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.Fail(c, "Invalid request data", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := m.userService.SetupMFA(c.Request.Context(), token, req)
+	if err != nil {
+		utils.Fail(c, "Unable to setup MFA", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (m *MFAController) Verify(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	var req dto.MFAVerifyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.Fail(c, "Invalid request data", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := m.userService.VerifyMFA(c.Request.Context(), token, req)
+	if err != nil {
+		utils.Fail(c, "Unable to verify MFA", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (m *MFAController) Disable(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	var req dto.MFADisableRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.Fail(c, "Invalid request data", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := m.userService.DisableMFA(c.Request.Context(), token, req)
+	if err != nil {
+		utils.Fail(c, "Unable to disable MFA", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (m *MFAController) Methods(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	resp, err := m.userService.GetMFAMethods(c.Request.Context(), token)
+	if err != nil {
+		utils.Fail(c, "Unable to fetch MFA methods", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}

--- a/bff-services/internal/api/controllers/password_controller.go
+++ b/bff-services/internal/api/controllers/password_controller.go
@@ -1,0 +1,72 @@
+package controllers
+
+import (
+	"net/http"
+
+	"bff-services/internal/api/dto"
+	"bff-services/internal/services"
+	"bff-services/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+type PasswordController struct {
+	userService services.UserService
+}
+
+func NewPasswordController(userService services.UserService) *PasswordController {
+	return &PasswordController{userService: userService}
+}
+
+func (p *PasswordController) RequestReset(c *gin.Context) {
+	var req dto.PasswordResetRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.Fail(c, "Invalid request data", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := p.userService.RequestPasswordReset(c.Request.Context(), req)
+	if err != nil {
+		utils.Fail(c, "Unable to initiate password reset", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (p *PasswordController) ConfirmReset(c *gin.Context) {
+	var req dto.PasswordResetConfirmRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.Fail(c, "Invalid request data", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := p.userService.ConfirmPasswordReset(c.Request.Context(), req)
+	if err != nil {
+		utils.Fail(c, "Unable to confirm password reset", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (p *PasswordController) ChangePassword(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	var req dto.ChangePasswordRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.Fail(c, "Invalid request data", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := p.userService.ChangePassword(c.Request.Context(), token, req)
+	if err != nil {
+		utils.Fail(c, "Unable to change password", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}

--- a/bff-services/internal/api/controllers/profile_controller.go
+++ b/bff-services/internal/api/controllers/profile_controller.go
@@ -1,0 +1,70 @@
+package controllers
+
+import (
+	"net/http"
+
+	"bff-services/internal/api/dto"
+	"bff-services/internal/services"
+	"bff-services/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+type ProfileController struct {
+	userService services.UserService
+}
+
+func NewProfileController(userService services.UserService) *ProfileController {
+	return &ProfileController{userService: userService}
+}
+
+func (p *ProfileController) GetProfile(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	resp, err := p.userService.GetProfile(c.Request.Context(), token)
+	if err != nil {
+		utils.Fail(c, "Unable to fetch profile", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (p *ProfileController) UpdateProfile(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	var req dto.UpdateProfileRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.Fail(c, "Invalid request data", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := p.userService.UpdateProfile(c.Request.Context(), token, req)
+	if err != nil {
+		utils.Fail(c, "Unable to update profile", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (p *ProfileController) CheckAuth(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	resp, err := p.userService.CheckAuth(c.Request.Context(), token)
+	if err != nil {
+		utils.Fail(c, "Unable to verify authentication", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}

--- a/bff-services/internal/api/controllers/response.go
+++ b/bff-services/internal/api/controllers/response.go
@@ -1,0 +1,45 @@
+package controllers
+
+import (
+	"net/http"
+	"strings"
+
+	"bff-services/internal/services"
+
+	"github.com/gin-gonic/gin"
+)
+
+func respondWithServiceResponse(c *gin.Context, resp *services.HTTPResponse) {
+	if resp == nil {
+		c.Status(http.StatusNoContent)
+		return
+	}
+
+	if resp.Headers != nil {
+		// Forward upstream headers except those managed by Gin automatically.
+		for key, values := range resp.Headers {
+			// Skip hop-by-hop headers
+			if strings.EqualFold(key, "Connection") || strings.EqualFold(key, "Keep-Alive") ||
+				strings.EqualFold(key, "Transfer-Encoding") || strings.EqualFold(key, "Upgrade") {
+				continue
+			}
+			for _, value := range values {
+				c.Header(key, value)
+			}
+		}
+	}
+
+	if resp.IsBodyEmpty() {
+		c.Status(resp.StatusCode)
+		return
+	}
+
+	contentType := "application/json"
+	if resp.Headers != nil {
+		if ct := resp.Headers.Get("Content-Type"); ct != "" {
+			contentType = ct
+		}
+	}
+
+	c.Data(resp.StatusCode, contentType, resp.Body)
+}

--- a/bff-services/internal/api/controllers/session_controller.go
+++ b/bff-services/internal/api/controllers/session_controller.go
@@ -1,0 +1,69 @@
+package controllers
+
+import (
+	"net/http"
+
+	"bff-services/internal/services"
+	"bff-services/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+type SessionController struct {
+	userService services.UserService
+}
+
+func NewSessionController(userService services.UserService) *SessionController {
+	return &SessionController{userService: userService}
+}
+
+func (s *SessionController) List(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	resp, err := s.userService.GetSessions(c.Request.Context(), token)
+	if err != nil {
+		utils.Fail(c, "Unable to fetch sessions", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (s *SessionController) Delete(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	sessionID := c.Param("id")
+	if sessionID == "" {
+		utils.Fail(c, "Session ID is required", http.StatusBadRequest, "missing session id")
+		return
+	}
+
+	resp, err := s.userService.DeleteSession(c.Request.Context(), token, sessionID)
+	if err != nil {
+		utils.Fail(c, "Unable to revoke session", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (s *SessionController) RevokeAll(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	resp, err := s.userService.RevokeAllSessions(c.Request.Context(), token)
+	if err != nil {
+		utils.Fail(c, "Unable to revoke sessions", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}

--- a/bff-services/internal/api/dto/mfa_dto.go
+++ b/bff-services/internal/api/dto/mfa_dto.go
@@ -1,0 +1,19 @@
+package dto
+
+// MFASetupRequest represents payload to setup MFA.
+type MFASetupRequest struct {
+	Type  string `json:"type" binding:"required"`
+	Label string `json:"label" binding:"required"`
+}
+
+// MFAVerifyRequest represents payload to verify an MFA method.
+type MFAVerifyRequest struct {
+	MethodID string `json:"method_id" binding:"required"`
+	Code     string `json:"code" binding:"required"`
+}
+
+// MFADisableRequest represents payload to disable an MFA method.
+type MFADisableRequest struct {
+	MethodID string `json:"method_id" binding:"required"`
+	Password string `json:"password" binding:"required"`
+}

--- a/bff-services/internal/api/dto/password_dto.go
+++ b/bff-services/internal/api/dto/password_dto.go
@@ -1,0 +1,18 @@
+package dto
+
+// PasswordResetRequest represents payload to initiate password reset.
+type PasswordResetRequest struct {
+	Email string `json:"email" binding:"required,email"`
+}
+
+// PasswordResetConfirmRequest represents payload to confirm password reset.
+type PasswordResetConfirmRequest struct {
+	Token       string `json:"token" binding:"required"`
+	NewPassword string `json:"new_password" binding:"required,min=8"`
+}
+
+// ChangePasswordRequest represents payload to change password for authenticated user.
+type ChangePasswordRequest struct {
+	OldPassword string `json:"old_password" binding:"required"`
+	NewPassword string `json:"new_password" binding:"required,min=8"`
+}

--- a/bff-services/internal/api/dto/profile_dto.go
+++ b/bff-services/internal/api/dto/profile_dto.go
@@ -1,0 +1,9 @@
+package dto
+
+// UpdateProfileRequest represents payload for updating user profile.
+type UpdateProfileRequest struct {
+	DisplayName string `json:"display_name" binding:"required"`
+	AvatarURL   string `json:"avatar_url" binding:"omitempty,url"`
+	Locale      string `json:"locale" binding:"omitempty"`
+	TimeZone    string `json:"time_zone" binding:"omitempty"`
+}

--- a/bff-services/internal/server/router.go
+++ b/bff-services/internal/server/router.go
@@ -20,17 +20,54 @@ func NewRouter(deps Deps) *gin.Engine {
 
 	r.GET("/health", controllers.Health)
 
-	var authCtrl *controllers.AuthController
+	var (
+		authCtrl     *controllers.AuthController
+		profileCtrl  *controllers.ProfileController
+		passwordCtrl *controllers.PasswordController
+		mfaCtrl      *controllers.MFAController
+		sessionCtrl  *controllers.SessionController
+	)
 	if deps.UserService != nil {
 		authCtrl = controllers.NewAuthController(deps.UserService)
+		profileCtrl = controllers.NewProfileController(deps.UserService)
+		passwordCtrl = controllers.NewPasswordController(deps.UserService)
+		mfaCtrl = controllers.NewMFAController(deps.UserService)
+		sessionCtrl = controllers.NewSessionController(deps.UserService)
 	}
 
 	api := r.Group("/api/v1")
 	{
 		api.GET("/health", controllers.Health)
 		if authCtrl != nil {
+			api.POST("/register", authCtrl.Register)
+			api.POST("/login", authCtrl.Login)
+			api.POST("/logout", authCtrl.Logout)
+			api.GET("/verify-email", authCtrl.VerifyEmail)
+
+			// Backwards compatibility for existing clients
 			api.POST("/user/register", authCtrl.Register)
 			api.POST("/user/login", authCtrl.Login)
+		}
+		if profileCtrl != nil {
+			api.GET("/profile", profileCtrl.GetProfile)
+			api.PUT("/profile", profileCtrl.UpdateProfile)
+			api.GET("/profile/check-auth", profileCtrl.CheckAuth)
+		}
+		if passwordCtrl != nil {
+			api.POST("/password/reset/request", passwordCtrl.RequestReset)
+			api.POST("/password/reset/confirm", passwordCtrl.ConfirmReset)
+			api.POST("/password/change", passwordCtrl.ChangePassword)
+		}
+		if mfaCtrl != nil {
+			api.POST("/mfa/setup", mfaCtrl.Setup)
+			api.POST("/mfa/verify", mfaCtrl.Verify)
+			api.POST("/mfa/disable", mfaCtrl.Disable)
+			api.GET("/mfa/methods", mfaCtrl.Methods)
+		}
+		if sessionCtrl != nil {
+			api.GET("/sessions", sessionCtrl.List)
+			api.DELETE("/sessions/:id", sessionCtrl.Delete)
+			api.POST("/sessions/revoke-all", sessionCtrl.RevokeAll)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- expand the BFF user service client to cover all user APIs and forward headers/responses verbatim
- add controllers and DTOs for profile, password, MFA, and session flows plus bearer-token validation helpers
- expose the new handlers on the Gin router, keeping legacy auth routes for backward compatibility

## Testing
- `go test ./...` *(hangs while resolving modules, aborted)*

------
https://chatgpt.com/codex/tasks/task_b_68dfa5b51948832a82213ff467787624