### PR TITLE
Add folder support and extend media metadata

### DIFF
--- a/content-services/graph/generated/generated.go
+++ b/content-services/graph/generated/generated.go
@@ -127,16 +127,19 @@ type ComplexityRoot struct {
 	}
 
 	MediaAsset struct {
-		Bytes       func(childComplexity int) int
-		CreatedAt   func(childComplexity int) int
-		DownloadURL func(childComplexity int) int
-		DurationMs  func(childComplexity int) int
-		ID          func(childComplexity int) int
-		Kind        func(childComplexity int) int
-		MimeType    func(childComplexity int) int
-		Sha256      func(childComplexity int) int
-		StorageKey  func(childComplexity int) int
-		UploadedBy  func(childComplexity int) int
+		Bytes        func(childComplexity int) int
+		CreatedAt    func(childComplexity int) int
+		DownloadURL  func(childComplexity int) int
+		DurationMs   func(childComplexity int) int
+		FolderID     func(childComplexity int) int
+		ID           func(childComplexity int) int
+		Kind         func(childComplexity int) int
+		MimeType     func(childComplexity int) int
+		OriginalName func(childComplexity int) int
+		Sha256       func(childComplexity int) int
+		StorageKey   func(childComplexity int) int
+		ThumbnailURL func(childComplexity int) int
+		UploadedBy   func(childComplexity int) int
 	}
 
 	Mutation struct {
@@ -664,6 +667,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.MediaAsset.DurationMs(childComplexity), true
+	case "MediaAsset.folderId":
+		if e.complexity.MediaAsset.FolderID == nil {
+			break
+		}
+
+		return e.complexity.MediaAsset.FolderID(childComplexity), true
 	case "MediaAsset.id":
 		if e.complexity.MediaAsset.ID == nil {
 			break
@@ -682,6 +691,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.MediaAsset.MimeType(childComplexity), true
+	case "MediaAsset.originalName":
+		if e.complexity.MediaAsset.OriginalName == nil {
+			break
+		}
+
+		return e.complexity.MediaAsset.OriginalName(childComplexity), true
 	case "MediaAsset.sha256":
 		if e.complexity.MediaAsset.Sha256 == nil {
 			break
@@ -694,6 +709,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.MediaAsset.StorageKey(childComplexity), true
+	case "MediaAsset.thumbnailURL":
+		if e.complexity.MediaAsset.ThumbnailURL == nil {
+			break
+		}
+
+		return e.complexity.MediaAsset.ThumbnailURL(childComplexity), true
 	case "MediaAsset.uploadedBy":
 		if e.complexity.MediaAsset.UploadedBy == nil {
 			break
@@ -1625,6 +1646,9 @@ type MediaAsset {
   storageKey: String!
   kind: MediaKind!
   mimeType: String!
+  folderId: ID
+  originalName: String!
+  thumbnailURL: String
   bytes: Int!
   durationMs: Int
   sha256: String!
@@ -1639,6 +1663,7 @@ input UploadMediaInput {
   mimeType: String!
   filename: String
   uploadedBy: ID
+  folderId: ID
 }
 
 
@@ -4180,6 +4205,93 @@ func (ec *executionContext) fieldContext_MediaAsset_mimeType(_ context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _MediaAsset_folderId(ctx context.Context, field graphql.CollectedField, obj *model.MediaAsset) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_MediaAsset_folderId,
+		func(ctx context.Context) (any, error) {
+			return obj.FolderID, nil
+		},
+		nil,
+		ec.marshalOID2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_MediaAsset_folderId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "MediaAsset",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _MediaAsset_originalName(ctx context.Context, field graphql.CollectedField, obj *model.MediaAsset) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_MediaAsset_originalName,
+		func(ctx context.Context) (any, error) {
+			return obj.OriginalName, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_MediaAsset_originalName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "MediaAsset",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _MediaAsset_thumbnailURL(ctx context.Context, field graphql.CollectedField, obj *model.MediaAsset) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_MediaAsset_thumbnailURL,
+		func(ctx context.Context) (any, error) {
+			return obj.ThumbnailURL, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_MediaAsset_thumbnailURL(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "MediaAsset",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _MediaAsset_bytes(ctx context.Context, field graphql.CollectedField, obj *model.MediaAsset) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -4808,6 +4920,12 @@ func (ec *executionContext) fieldContext_Mutation_uploadMedia(ctx context.Contex
 				return ec.fieldContext_MediaAsset_kind(ctx, field)
 			case "mimeType":
 				return ec.fieldContext_MediaAsset_mimeType(ctx, field)
+			case "folderId":
+				return ec.fieldContext_MediaAsset_folderId(ctx, field)
+			case "originalName":
+				return ec.fieldContext_MediaAsset_originalName(ctx, field)
+			case "thumbnailURL":
+				return ec.fieldContext_MediaAsset_thumbnailURL(ctx, field)
 			case "bytes":
 				return ec.fieldContext_MediaAsset_bytes(ctx, field)
 			case "durationMs":
@@ -6125,6 +6243,12 @@ func (ec *executionContext) fieldContext_Query_mediaAsset(ctx context.Context, f
 				return ec.fieldContext_MediaAsset_kind(ctx, field)
 			case "mimeType":
 				return ec.fieldContext_MediaAsset_mimeType(ctx, field)
+			case "folderId":
+				return ec.fieldContext_MediaAsset_folderId(ctx, field)
+			case "originalName":
+				return ec.fieldContext_MediaAsset_originalName(ctx, field)
+			case "thumbnailURL":
+				return ec.fieldContext_MediaAsset_thumbnailURL(ctx, field)
 			case "bytes":
 				return ec.fieldContext_MediaAsset_bytes(ctx, field)
 			case "durationMs":
@@ -6188,6 +6312,12 @@ func (ec *executionContext) fieldContext_Query_mediaAssets(ctx context.Context, 
 				return ec.fieldContext_MediaAsset_kind(ctx, field)
 			case "mimeType":
 				return ec.fieldContext_MediaAsset_mimeType(ctx, field)
+			case "folderId":
+				return ec.fieldContext_MediaAsset_folderId(ctx, field)
+			case "originalName":
+				return ec.fieldContext_MediaAsset_originalName(ctx, field)
+			case "thumbnailURL":
+				return ec.fieldContext_MediaAsset_thumbnailURL(ctx, field)
 			case "bytes":
 				return ec.fieldContext_MediaAsset_bytes(ctx, field)
 			case "durationMs":
@@ -10053,7 +10183,7 @@ func (ec *executionContext) unmarshalInputUploadMediaInput(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"file", "kind", "mimeType", "filename", "uploadedBy"}
+	fieldsInOrder := [...]string{"file", "kind", "mimeType", "filename", "uploadedBy", "folderId"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -10095,6 +10225,13 @@ func (ec *executionContext) unmarshalInputUploadMediaInput(ctx context.Context, 
 				return it, err
 			}
 			it.UploadedBy = data
+		case "folderId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("folderId"))
+			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FolderID = data
 		}
 	}
 
@@ -10780,6 +10917,15 @@ func (ec *executionContext) _MediaAsset(ctx context.Context, sel ast.SelectionSe
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "folderId":
+			out.Values[i] = ec._MediaAsset_folderId(ctx, field, obj)
+		case "originalName":
+			out.Values[i] = ec._MediaAsset_originalName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "thumbnailURL":
+			out.Values[i] = ec._MediaAsset_thumbnailURL(ctx, field, obj)
 		case "bytes":
 			out.Values[i] = ec._MediaAsset_bytes(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/content-services/graph/model/models_gen.go
+++ b/content-services/graph/model/models_gen.go
@@ -169,16 +169,19 @@ type Level struct {
 }
 
 type MediaAsset struct {
-	ID          string    `json:"id"`
-	StorageKey  string    `json:"storageKey"`
-	Kind        MediaKind `json:"kind"`
-	MimeType    string    `json:"mimeType"`
-	Bytes       int       `json:"bytes"`
-	DurationMs  *int      `json:"durationMs,omitempty"`
-	Sha256      string    `json:"sha256"`
-	CreatedAt   time.Time `json:"createdAt"`
-	UploadedBy  *string   `json:"uploadedBy,omitempty"`
-	DownloadURL string    `json:"downloadURL"`
+	ID           string    `json:"id"`
+	StorageKey   string    `json:"storageKey"`
+	Kind         MediaKind `json:"kind"`
+	MimeType     string    `json:"mimeType"`
+	FolderID     *string   `json:"folderId,omitempty"`
+	OriginalName string    `json:"originalName"`
+	ThumbnailURL *string   `json:"thumbnailURL,omitempty"`
+	Bytes        int       `json:"bytes"`
+	DurationMs   *int      `json:"durationMs,omitempty"`
+	Sha256       string    `json:"sha256"`
+	CreatedAt    time.Time `json:"createdAt"`
+	UploadedBy   *string   `json:"uploadedBy,omitempty"`
+	DownloadURL  string    `json:"downloadURL"`
 }
 
 type Mutation struct {
@@ -278,6 +281,7 @@ type UploadMediaInput struct {
 	MimeType   string         `json:"mimeType"`
 	Filename   *string        `json:"filename,omitempty"`
 	UploadedBy *string        `json:"uploadedBy,omitempty"`
+	FolderID   *string        `json:"folderId,omitempty"`
 }
 
 type ContentTagKind string

--- a/content-services/graph/resolver/helpers.go
+++ b/content-services/graph/resolver/helpers.go
@@ -308,6 +308,18 @@ func (r *Resolver) mapMediaAsset(ctx context.Context, media *models.MediaAsset) 
 		uploadedBy = &id
 	}
 
+	var folderID *string
+	if media.FolderID != nil {
+		id := media.FolderID.String()
+		folderID = &id
+	}
+
+	var thumbnailURL *string
+	if media.ThumbnailURL != "" {
+		url := media.ThumbnailURL
+		thumbnailURL = &url
+	}
+
 	duration := toIntPtr(media.DurationMs)
 
 	if media.ID == uuid.Nil {
@@ -324,16 +336,19 @@ func (r *Resolver) mapMediaAsset(ctx context.Context, media *models.MediaAsset) 
 	}
 
 	return &model.MediaAsset{
-		ID:          media.ID.String(),
-		StorageKey:  media.StorageKey,
-		Kind:        mapMediaKind(media.Kind),
-		MimeType:    media.MimeType,
-		Bytes:       media.Bytes,
-		DurationMs:  duration,
-		Sha256:      media.SHA256,
-		CreatedAt:   media.CreatedAt,
-		UploadedBy:  uploadedBy,
-		DownloadURL: downloadURL,
+		ID:           media.ID.String(),
+		StorageKey:   media.StorageKey,
+		Kind:         mapMediaKind(media.Kind),
+		MimeType:     media.MimeType,
+		FolderID:     folderID,
+		OriginalName: media.OriginalName,
+		ThumbnailURL: thumbnailURL,
+		Bytes:        media.Bytes,
+		DurationMs:   duration,
+		Sha256:       media.SHA256,
+		CreatedAt:    media.CreatedAt,
+		UploadedBy:   uploadedBy,
+		DownloadURL:  downloadURL,
 	}, nil
 }
 

--- a/content-services/graph/resolver/mutation_media.go
+++ b/content-services/graph/resolver/mutation_media.go
@@ -43,7 +43,16 @@ func (r *mutationResolver) UploadMedia(ctx context.Context, input model.UploadMe
 		userID = parsed
 	}
 
-	media, err := r.Media.UploadMedia(ctx, upload.File, filename, input.MimeType, kind, userID)
+	var folderID *uuid.UUID
+	if input.FolderID != nil && *input.FolderID != "" {
+		parsed, err := uuid.Parse(*input.FolderID)
+		if err != nil {
+			return nil, gqlerror.Errorf("invalid folderId: %v", err)
+		}
+		folderID = &parsed
+	}
+
+	media, err := r.Media.UploadMedia(ctx, upload.File, filename, input.MimeType, kind, userID, folderID)
 	if err != nil {
 		return nil, err
 	}

--- a/content-services/graph/schema.graphqls
+++ b/content-services/graph/schema.graphqls
@@ -128,6 +128,9 @@ type MediaAsset {
   storageKey: String!
   kind: MediaKind!
   mimeType: String!
+  folderId: ID
+  originalName: String!
+  thumbnailURL: String
   bytes: Int!
   durationMs: Int
   sha256: String!
@@ -142,6 +145,7 @@ input UploadMediaInput {
   mimeType: String!
   filename: String
   uploadedBy: ID
+  folderId: ID
 }
 
 

--- a/content-services/internal/models/content_models.go
+++ b/content-services/internal/models/content_models.go
@@ -29,17 +29,27 @@ type Tag struct {
 	Name string    `gorm:"type:text;not null" json:"name"`
 }
 
+// Folder groups media assets
+type Folder struct {
+	ID        uuid.UUID `gorm:"type:uuid;default:uuid_generate_v4();primaryKey" json:"id" bson:"_id"`
+	Name      string    `gorm:"type:text;not null" json:"name" bson:"name"`
+	CreatedAt time.Time `gorm:"default:now();not null" json:"created_at" bson:"created_at"`
+}
+
 // MediaAsset for images and audio files
 type MediaAsset struct {
-	ID         uuid.UUID  `gorm:"type:uuid;default:uuid_generate_v4();primaryKey" json:"id" bson:"_id"`
-	StorageKey string     `gorm:"type:text;uniqueIndex;not null" json:"storage_key" bson:"storage_key"` // S3/MinIO key
-	Kind       string     `gorm:"type:text;not null;check:kind IN ('image','audio')" json:"kind" bson:"kind"`
-	MimeType   string     `gorm:"type:text;not null" json:"mime_type" bson:"mime_type"`
-	Bytes      int        `json:"bytes,omitempty" bson:"bytes"`
-	DurationMs int        `json:"duration_ms,omitempty" bson:"duration_ms"` // for audio
-	SHA256     string     `gorm:"type:text;not null;index:media_sha_idx" json:"sha256" bson:"sha256"`
-	CreatedAt  time.Time  `gorm:"default:now();not null" json:"created_at" bson:"created_at"`
-	UploadedBy *uuid.UUID `gorm:"type:uuid" json:"uploaded_by,omitempty" bson:"uploaded_by,omitempty"` // logical FK to users
+	ID           uuid.UUID  `gorm:"type:uuid;default:uuid_generate_v4();primaryKey" json:"id" bson:"_id"`
+	StorageKey   string     `gorm:"type:text;uniqueIndex;not null" json:"storage_key" bson:"storage_key"` // S3/MinIO key
+	Kind         string     `gorm:"type:text;not null;check:kind IN ('image','audio')" json:"kind" bson:"kind"`
+	MimeType     string     `gorm:"type:text;not null" json:"mime_type" bson:"mime_type"`
+	FolderID     *uuid.UUID `gorm:"type:uuid" json:"folder_id,omitempty" bson:"folder_id,omitempty"`
+	OriginalName string     `gorm:"type:text;not null" json:"original_name" bson:"original_name"`
+	ThumbnailURL string     `gorm:"type:text" json:"thumbnail_url,omitempty" bson:"thumbnail_url,omitempty"`
+	Bytes        int        `json:"bytes,omitempty" bson:"bytes"`
+	DurationMs   int        `json:"duration_ms,omitempty" bson:"duration_ms"` // for audio
+	SHA256       string     `gorm:"type:text;not null;index:media_sha_idx" json:"sha256" bson:"sha256"`
+	CreatedAt    time.Time  `gorm:"default:now();not null" json:"created_at" bson:"created_at"`
+	UploadedBy   *uuid.UUID `gorm:"type:uuid" json:"uploaded_by,omitempty" bson:"uploaded_by,omitempty"` // logical FK to user
 }
 
 // Lesson modular content with versioning

--- a/content-services/internal/service/media_service.go
+++ b/content-services/internal/service/media_service.go
@@ -19,7 +19,7 @@ import (
 )
 
 type MediaService interface {
-	UploadMedia(ctx context.Context, file io.Reader, filename, mimeType, kind string, userID uuid.UUID) (*models.MediaAsset, error)
+	UploadMedia(ctx context.Context, file io.Reader, filename, mimeType, kind string, userID uuid.UUID, folderID *uuid.UUID) (*models.MediaAsset, error)
 	GetMediaByID(ctx context.Context, id uuid.UUID) (*models.MediaAsset, error)
 	GetMediaByIDs(ctx context.Context, ids []uuid.UUID) ([]models.MediaAsset, error)
 	GetPresignedURL(ctx context.Context, id uuid.UUID) (string, error)
@@ -40,7 +40,7 @@ func NewMediaService(mediaRepo repository.MediaRepository, storage storage.Objec
 	}
 }
 
-func (s *mediaService) UploadMedia(ctx context.Context, file io.Reader, filename, mimeType, kind string, userID uuid.UUID) (*models.MediaAsset, error) {
+func (s *mediaService) UploadMedia(ctx context.Context, file io.Reader, filename, mimeType, kind string, userID uuid.UUID, folderID *uuid.UUID) (*models.MediaAsset, error) {
 	if file == nil {
 		return nil, errors.New("media: file reader is required")
 	}
@@ -79,12 +79,14 @@ func (s *mediaService) UploadMedia(ctx context.Context, file io.Reader, filename
 	}
 
 	media := &models.MediaAsset{
-		StorageKey: key,
-		Kind:       kind,
-		MimeType:   mimeType,
-		Bytes:      int(written),
-		SHA256:     checksum,
-		CreatedAt:  time.Now().UTC(),
+		StorageKey:   key,
+		Kind:         kind,
+		MimeType:     mimeType,
+		FolderID:     folderID,
+		OriginalName: filename,
+		Bytes:        int(written),
+		SHA256:       checksum,
+		CreatedAt:    time.Now().UTC(),
 	}
 	if userID != uuid.Nil {
 		uid := userID


### PR DESCRIPTION
## Summary
- add a Folder model and extend media assets with folder, original name, and thumbnail metadata
- expose the new media asset fields through the GraphQL schema and resolvers, including folder selection on upload
- store the original filename and folder reference during uploads so GraphQL responses return the richer metadata

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68e0a55308ac832a9cada11f31729572