### PR TITLE
feat: add content service integration to bff

### DIFF
--- a/bff-services/cmd/server/main.go
+++ b/bff-services/cmd/server/main.go
@@ -20,10 +20,12 @@ func main() {
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 
 	userService := services.NewUserServiceClient(config.GetUserServiceURL(), nil)
+	contentService := services.NewContentServiceClient(config.GetContentServiceURL(), nil)
 
 	addr := ":" + port
 	r := server.NewRouter(server.Deps{
-		UserService: userService,
+		UserService:    userService,
+		ContentService: contentService,
 	})
 
 	srv := &http.Server{

--- a/bff-services/internal/api/controllers/content_controller.go
+++ b/bff-services/internal/api/controllers/content_controller.go
@@ -1,0 +1,113 @@
+package controllers
+
+import (
+	"net/http"
+
+	"bff-services/internal/api/dto"
+	"bff-services/internal/services"
+	"bff-services/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ContentController proxies content related operations to the content service.
+type ContentController struct {
+	contentService services.ContentService
+}
+
+// NewContentController constructs a new ContentController instance.
+func NewContentController(contentService services.ContentService) *ContentController {
+	return &ContentController{contentService: contentService}
+}
+
+// GetTopicsLevelsTags fetches topics, levels and tags metadata.
+func (c *ContentController) GetTopicsLevelsTags(ctx *gin.Context) {
+	token := getOptionalBearerToken(ctx)
+
+	resp, err := c.contentService.GetTopicsLevelsTags(ctx.Request.Context(), token)
+	if err != nil {
+		utils.Fail(ctx, "Unable to fetch content metadata", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(ctx, resp)
+}
+
+// GetLessons fetches lessons using the provided query parameters.
+func (c *ContentController) GetLessons(ctx *gin.Context) {
+	token := getOptionalBearerToken(ctx)
+
+	var params dto.LessonQueryParams
+	if err := ctx.ShouldBindQuery(&params); err != nil {
+		utils.Fail(ctx, "Invalid query parameters", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := c.contentService.GetLessons(ctx.Request.Context(), token, params)
+	if err != nil {
+		utils.Fail(ctx, "Unable to fetch lessons", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(ctx, resp)
+}
+
+// CreateLesson proxies lesson creation to the content service.
+func (c *ContentController) CreateLesson(ctx *gin.Context) {
+	token, ok := requireBearerToken(ctx)
+	if !ok {
+		return
+	}
+
+	var payload dto.CreateLessonRequest
+	if err := ctx.ShouldBindJSON(&payload); err != nil {
+		utils.Fail(ctx, "Invalid request payload", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := c.contentService.CreateLesson(ctx.Request.Context(), token, payload)
+	if err != nil {
+		utils.Fail(ctx, "Unable to create lesson", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(ctx, resp)
+}
+
+// GetFlashcardSets fetches flashcard sets from the content service.
+func (c *ContentController) GetFlashcardSets(ctx *gin.Context) {
+	token := getOptionalBearerToken(ctx)
+
+	var params dto.FlashcardQueryParams
+	if err := ctx.ShouldBindQuery(&params); err != nil {
+		utils.Fail(ctx, "Invalid query parameters", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := c.contentService.GetFlashcardSets(ctx.Request.Context(), token, params)
+	if err != nil {
+		utils.Fail(ctx, "Unable to fetch flashcard sets", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(ctx, resp)
+}
+
+// GetQuizzes fetches quizzes for a specific lesson.
+func (c *ContentController) GetQuizzes(ctx *gin.Context) {
+	token := getOptionalBearerToken(ctx)
+
+	var params dto.QuizQueryParams
+	if err := ctx.ShouldBindQuery(&params); err != nil {
+		utils.Fail(ctx, "Invalid query parameters", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := c.contentService.GetQuizzes(ctx.Request.Context(), token, params)
+	if err != nil {
+		utils.Fail(ctx, "Unable to fetch quizzes", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(ctx, resp)
+}

--- a/bff-services/internal/api/controllers/helpers.go
+++ b/bff-services/internal/api/controllers/helpers.go
@@ -26,3 +26,18 @@ func requireBearerToken(c *gin.Context) (string, bool) {
 
 	return strings.TrimSpace(parts[1]), true
 }
+
+// getOptionalBearerToken extracts the bearer token if present; returns empty string otherwise.
+func getOptionalBearerToken(c *gin.Context) string {
+	header := c.GetHeader("Authorization")
+	if header == "" {
+		return ""
+	}
+
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return ""
+	}
+
+	return strings.TrimSpace(parts[1])
+}

--- a/bff-services/internal/api/dto/content_dto.go
+++ b/bff-services/internal/api/dto/content_dto.go
@@ -1,0 +1,34 @@
+package dto
+
+// LessonQueryParams represents query parameters for listing lessons.
+type LessonQueryParams struct {
+	TopicID     string `form:"topicId"`
+	LevelID     string `form:"levelId"`
+	IsPublished *bool  `form:"isPublished"`
+	Page        int    `form:"page,default=1"`
+	PageSize    int    `form:"pageSize,default=10"`
+}
+
+// CreateLessonRequest represents the payload for creating a lesson.
+type CreateLessonRequest struct {
+	Title       string `json:"title" binding:"required"`
+	Description string `json:"description"`
+	TopicID     string `json:"topicId" binding:"required"`
+	LevelID     string `json:"levelId" binding:"required"`
+	CreatedBy   string `json:"createdBy"`
+}
+
+// FlashcardQueryParams represents query parameters for listing flashcard sets.
+type FlashcardQueryParams struct {
+	TopicID  string `form:"topicId"`
+	LevelID  string `form:"levelId"`
+	Page     int    `form:"page,default=1"`
+	PageSize int    `form:"pageSize,default=10"`
+}
+
+// QuizQueryParams represents query parameters for listing quizzes.
+type QuizQueryParams struct {
+	LessonID string `form:"lessonId" binding:"required"`
+	Page     int    `form:"page,default=1"`
+	PageSize int    `form:"pageSize,default=10"`
+}

--- a/bff-services/internal/config/config.go
+++ b/bff-services/internal/config/config.go
@@ -31,6 +31,13 @@ func GetUserServiceURL() string {
 	return "http://localhost:8001"
 }
 
+func GetContentServiceURL() string {
+	if v := os.Getenv("CONTENT_SERVICE_URL"); v != "" {
+		return v
+	}
+	return "http://localhost/api/content"
+}
+
 // GetCORSOrigin returns allowed CORS origin from env CORS_URL; default http://localhost:3000
 func GetCORSOrigin() string {
 	if v := os.Getenv("CORS_URL"); v != "" {

--- a/bff-services/internal/server/router.go
+++ b/bff-services/internal/server/router.go
@@ -9,7 +9,8 @@ import (
 )
 
 type Deps struct {
-	UserService services.UserService
+	UserService    services.UserService
+	ContentService services.ContentService
 }
 
 func NewRouter(deps Deps) *gin.Engine {
@@ -40,6 +41,7 @@ func NewRouter(deps Deps) *gin.Engine {
 		passwordCtrl *controllers.PasswordController
 		mfaCtrl      *controllers.MFAController
 		sessionCtrl  *controllers.SessionController
+		contentCtrl  *controllers.ContentController
 	)
 	if deps.UserService != nil {
 		authCtrl = controllers.NewAuthController(deps.UserService)
@@ -47,6 +49,9 @@ func NewRouter(deps Deps) *gin.Engine {
 		passwordCtrl = controllers.NewPasswordController(deps.UserService)
 		mfaCtrl = controllers.NewMFAController(deps.UserService)
 		sessionCtrl = controllers.NewSessionController(deps.UserService)
+	}
+	if deps.ContentService != nil {
+		contentCtrl = controllers.NewContentController(deps.ContentService)
 	}
 
 	api := r.Group("/api/v1")
@@ -82,6 +87,16 @@ func NewRouter(deps Deps) *gin.Engine {
 			api.GET("/sessions", sessionCtrl.List)
 			api.DELETE("/sessions/:id", sessionCtrl.Delete)
 			api.POST("/sessions/revoke-all", sessionCtrl.RevokeAll)
+		}
+		if contentCtrl != nil {
+			content := api.Group("/content")
+			{
+				content.GET("/metadata", contentCtrl.GetTopicsLevelsTags)
+				content.GET("/lessons", contentCtrl.GetLessons)
+				content.POST("/lessons", contentCtrl.CreateLesson)
+				content.GET("/flashcards", contentCtrl.GetFlashcardSets)
+				content.GET("/quizzes", contentCtrl.GetQuizzes)
+			}
 		}
 	}
 

--- a/bff-services/internal/services/content_service.go
+++ b/bff-services/internal/services/content_service.go
@@ -1,0 +1,261 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"bff-services/internal/api/dto"
+)
+
+// ContentService defines the contract for interacting with the content service GraphQL API.
+type ContentService interface {
+	GetTopicsLevelsTags(ctx context.Context, token string) (*HTTPResponse, error)
+	GetLessons(ctx context.Context, token string, params dto.LessonQueryParams) (*HTTPResponse, error)
+	CreateLesson(ctx context.Context, token string, payload dto.CreateLessonRequest) (*HTTPResponse, error)
+	GetFlashcardSets(ctx context.Context, token string, params dto.FlashcardQueryParams) (*HTTPResponse, error)
+	GetQuizzes(ctx context.Context, token string, params dto.QuizQueryParams) (*HTTPResponse, error)
+}
+
+// ContentServiceClient implements ContentService against a remote HTTP GraphQL endpoint.
+type ContentServiceClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+type graphQLRequest struct {
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables,omitempty"`
+}
+
+// NewContentServiceClient constructs a new ContentServiceClient.
+func NewContentServiceClient(baseURL string, httpClient *http.Client) *ContentServiceClient {
+	trimmed := strings.TrimRight(baseURL, "/")
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &ContentServiceClient{
+		baseURL:    trimmed,
+		httpClient: httpClient,
+	}
+}
+
+const (
+	topicsLevelsTagsQuery = `query {
+  topics {
+    id
+    slug
+    name
+    createdAt
+  }
+  levels {
+    id
+    code
+    name
+  }
+  tags {
+    id
+    slug
+    name
+  }
+}`
+
+	lessonsQuery = `query ($filter: LessonFilterInput, $page: Int, $pageSize: Int) {
+  lessons(filter: $filter, page: $page, pageSize: $pageSize) {
+    items {
+      id
+      code
+      title
+      description
+      topic {
+        id
+        name
+      }
+      level {
+        id
+        name
+      }
+      isPublished
+      createdAt
+      sections {
+        id
+        type
+        body
+      }
+    }
+    totalCount
+  }
+}`
+
+	createLessonMutation = `mutation ($input: CreateLessonInput!) {
+  createLesson(input: $input) {
+    id
+    title
+    code
+  }
+}`
+
+	flashcardSetsQuery = `query ($topicId: ID, $levelId: ID, $page: Int, $pageSize: Int) {
+  flashcardSets(topicId: $topicId, levelId: $levelId, page: $page, pageSize: $pageSize) {
+    items {
+      id
+      title
+      description
+      cards {
+        id
+        frontText
+        backText
+        hints
+      }
+    }
+    totalCount
+  }
+}`
+
+	quizzesQuery = `query ($lessonId: ID!, $page: Int, $pageSize: Int) {
+  quizzes(lessonId: $lessonId, page: $page, pageSize: $pageSize) {
+    items {
+      id
+      title
+    }
+  }
+}`
+)
+
+// GetTopicsLevelsTags fetches topics, levels, and tags metadata.
+func (c *ContentServiceClient) GetTopicsLevelsTags(ctx context.Context, token string) (*HTTPResponse, error) {
+	return c.doGraphQLRequest(ctx, topicsLevelsTagsQuery, nil, token)
+}
+
+// GetLessons fetches paginated lessons using optional filters.
+func (c *ContentServiceClient) GetLessons(ctx context.Context, token string, params dto.LessonQueryParams) (*HTTPResponse, error) {
+	variables := make(map[string]interface{})
+	filter := make(map[string]interface{})
+
+	if params.TopicID != "" {
+		filter["topicId"] = params.TopicID
+	}
+	if params.LevelID != "" {
+		filter["levelId"] = params.LevelID
+	}
+	if params.IsPublished != nil {
+		filter["isPublished"] = *params.IsPublished
+	}
+	if len(filter) > 0 {
+		variables["filter"] = filter
+	}
+	if params.Page > 0 {
+		variables["page"] = params.Page
+	}
+	if params.PageSize > 0 {
+		variables["pageSize"] = params.PageSize
+	}
+
+	return c.doGraphQLRequest(ctx, lessonsQuery, variables, token)
+}
+
+// CreateLesson creates a new lesson.
+func (c *ContentServiceClient) CreateLesson(ctx context.Context, token string, payload dto.CreateLessonRequest) (*HTTPResponse, error) {
+	input := map[string]interface{}{
+		"title":       payload.Title,
+		"description": payload.Description,
+		"topicId":     payload.TopicID,
+		"levelId":     payload.LevelID,
+	}
+	if payload.CreatedBy != "" {
+		input["createdBy"] = payload.CreatedBy
+	}
+
+	variables := map[string]interface{}{
+		"input": input,
+	}
+
+	return c.doGraphQLRequest(ctx, createLessonMutation, variables, token)
+}
+
+// GetFlashcardSets fetches flashcard sets with optional filters.
+func (c *ContentServiceClient) GetFlashcardSets(ctx context.Context, token string, params dto.FlashcardQueryParams) (*HTTPResponse, error) {
+	variables := make(map[string]interface{})
+	if params.TopicID != "" {
+		variables["topicId"] = params.TopicID
+	}
+	if params.LevelID != "" {
+		variables["levelId"] = params.LevelID
+	}
+	if params.Page > 0 {
+		variables["page"] = params.Page
+	}
+	if params.PageSize > 0 {
+		variables["pageSize"] = params.PageSize
+	}
+
+	return c.doGraphQLRequest(ctx, flashcardSetsQuery, variables, token)
+}
+
+// GetQuizzes fetches quizzes for a lesson.
+func (c *ContentServiceClient) GetQuizzes(ctx context.Context, token string, params dto.QuizQueryParams) (*HTTPResponse, error) {
+	if params.LessonID == "" {
+		return nil, fmt.Errorf("lessonId is required")
+	}
+
+	variables := map[string]interface{}{
+		"lessonId": params.LessonID,
+	}
+	if params.Page > 0 {
+		variables["page"] = params.Page
+	}
+	if params.PageSize > 0 {
+		variables["pageSize"] = params.PageSize
+	}
+
+	return c.doGraphQLRequest(ctx, quizzesQuery, variables, token)
+}
+
+func (c *ContentServiceClient) doGraphQLRequest(ctx context.Context, query string, variables map[string]interface{}, token string) (*HTTPResponse, error) {
+	if c.baseURL == "" {
+		return nil, fmt.Errorf("content service base URL is not configured")
+	}
+
+	payload := graphQLRequest{Query: query}
+	if len(variables) > 0 {
+		payload.Variables = variables
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal graphql payload: %w", err)
+	}
+
+	endpoint := c.baseURL + "/graphql"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create graphql request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("perform graphql request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read graphql response: %w", err)
+	}
+
+	return &HTTPResponse{
+		StatusCode: resp.StatusCode,
+		Body:       respBody,
+		Headers:    resp.Header.Clone(),
+	}, nil
+}


### PR DESCRIPTION
## Summary
- add a content service GraphQL client and DTOs for lessons, flashcards, and quizzes
- expose metadata, lessons, flashcards, and quiz routes through a new content controller
- wire the content service into the router, configuration, and server startup with optional bearer token support

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68e0a6f364d8832aa5238f6191c5ddfd