### PR TITLE
Add spaced repetition card and review endpoints

### DIFF
--- a/lesson-services/app/routers/sr_review_routes.py
+++ b/lesson-services/app/routers/sr_review_routes.py
@@ -1,60 +1,85 @@
-from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session
-from typing import List
+from datetime import date
+from typing import List, Optional
 from uuid import UUID
-from datetime import datetime
 
-# Import dependencies
-# from app.database.connection import get_db
-# from app.services.sr_review_service import SRReviewService
-# from app.schemas.sr_schema import SRReviewCreate, SRReviewResponse
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.orm import Session
+
+from app.database.connection import get_db
+from app.schemas.progress_schema import (
+    SRReviewCreate,
+    SRReviewResponse,
+    SRReviewStatsResponse,
+    SRReviewTodayStatsResponse,
+)
+from app.services.sr_review_service import SRReviewService
 
 router = APIRouter(prefix="/api/spaced-repetition/reviews", tags=["Spaced Repetition Reviews"])
 
-# POST /api/spaced-repetition/reviews
-# Logic: Record a flashcard review
-# - Validate request body (user_id, flashcard_id, quality 0-5)
-# - Find corresponding SR card
-# - Record review with interval snapshots
-# - Update SR card using SM-2 algorithm
-# - Set reviewed_at to current timestamp
-# - Update daily_activity (minutes, points)
-# - Return review record with new card schedule
 
-# GET /api/spaced-repetition/reviews/user/{user_id}
-# Logic: Get review history for user
-# - Optional query params: limit, offset, date_from, date_to
-# - Fetch all sr_reviews for user_id
-# - Order by reviewed_at DESC
-# - Apply pagination and date filters
-# - Return list of review records
+def _get_service(db: Session) -> SRReviewService:
+    return SRReviewService(db)
 
-# GET /api/spaced-repetition/reviews/user/{user_id}/flashcard/{flashcard_id}
-# Logic: Get review history for specific flashcard
-# - Fetch all reviews for user_id + flashcard_id combination
-# - Order by reviewed_at DESC
-# - Return list showing progress over time
 
-# GET /api/spaced-repetition/reviews/user/{user_id}/today
-# Logic: Get today's review activity
-# - Filter reviews by user_id and reviewed_at >= start_of_day
-# - Count total reviews
-# - Calculate average quality
-# - Group by quality rating
-# - Return today's review statistics
+@router.post("", response_model=SRReviewResponse, status_code=status.HTTP_201_CREATED)
+def create_review(payload: SRReviewCreate, db: Session = Depends(get_db)) -> SRReviewResponse:
+    service = _get_service(db)
+    try:
+        review = service.create_review(payload)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    return SRReviewResponse.model_validate(review, from_attributes=True)
 
-# GET /api/spaced-repetition/reviews/user/{user_id}/stats
-# Logic: Get comprehensive review statistics
-# - Count total reviews all time
-# - Calculate average quality
-# - Count reviews by quality (0-5)
-# - Calculate retention rate (quality >= 3)
-# - Get review streak (consecutive days)
-# - Return detailed statistics
 
-# DELETE /api/spaced-repetition/reviews/{review_id}
-# Logic: Delete review record (admin/cleanup)
-# - Note: This doesn't undo SR card state changes
-# - Delete sr_review record
-# - Return 204 No Content
+@router.get("/user/{user_id}", response_model=List[SRReviewResponse])
+def get_user_reviews(
+    user_id: UUID,
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    date_from: Optional[date] = Query(None),
+    date_to: Optional[date] = Query(None),
+    db: Session = Depends(get_db),
+) -> List[SRReviewResponse]:
+    service = _get_service(db)
+    reviews = service.get_user_reviews(
+        user_id,
+        limit=limit,
+        offset=offset,
+        date_from=date_from,
+        date_to=date_to,
+    )
+    return [SRReviewResponse.model_validate(review, from_attributes=True) for review in reviews]
 
+
+@router.get("/user/{user_id}/flashcard/{flashcard_id}", response_model=List[SRReviewResponse])
+def get_flashcard_reviews(
+    user_id: UUID,
+    flashcard_id: UUID,
+    db: Session = Depends(get_db),
+) -> List[SRReviewResponse]:
+    service = _get_service(db)
+    reviews = service.get_flashcard_reviews(user_id, flashcard_id)
+    return [SRReviewResponse.model_validate(review, from_attributes=True) for review in reviews]
+
+
+@router.get("/user/{user_id}/today", response_model=SRReviewTodayStatsResponse)
+def get_today_review_stats(user_id: UUID, db: Session = Depends(get_db)) -> SRReviewTodayStatsResponse:
+    service = _get_service(db)
+    stats = service.get_today_stats(user_id)
+    return SRReviewTodayStatsResponse(**stats)
+
+
+@router.get("/user/{user_id}/stats", response_model=SRReviewStatsResponse)
+def get_user_review_stats(user_id: UUID, db: Session = Depends(get_db)) -> SRReviewStatsResponse:
+    service = _get_service(db)
+    stats = service.get_user_review_stats(user_id)
+    return SRReviewStatsResponse(**stats)
+
+
+@router.delete("/{review_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_review(review_id: UUID, db: Session = Depends(get_db)) -> Response:
+    service = _get_service(db)
+    deleted = service.delete_review(review_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="SR review not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/lesson-services/app/schemas/progress_schema.py
+++ b/lesson-services/app/schemas/progress_schema.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Optional, List
+from typing import Optional, List, Dict
 from datetime import datetime, date
 from uuid import UUID
 from enum import Enum
@@ -139,9 +139,20 @@ class SRCardUpdate(BaseModel):
 class SRCardResponse(SRCardBase):
     id: UUID
     due_at: datetime
-    
+
     class Config:
         from_attributes = True
+
+
+class SRCardStatsResponse(BaseModel):
+    total_cards: int
+    due_cards: int
+    suspended_cards: int
+    new_cards: int
+    learning_cards: int
+    mature_cards: int
+    average_ease_factor: float
+    average_interval: float
 
 class SRReviewBase(BaseModel):
     user_id: UUID
@@ -157,9 +168,28 @@ class SRReviewCreate(SRReviewBase):
 class SRReviewResponse(SRReviewBase):
     id: UUID
     reviewed_at: datetime
-    
+
     class Config:
         from_attributes = True
+
+
+class SRReviewTodayStatsResponse(BaseModel):
+    total_reviews: int
+    average_quality: float
+    quality_distribution: Dict[int, int]
+    retention_rate: float
+
+
+class SRReviewStatsResponse(BaseModel):
+    total_reviews: int
+    average_quality: float
+    quality_distribution: Dict[int, int]
+    retention_rate: float
+    review_streak: int
+    unique_flashcards: int
+    busiest_day: Optional[date]
+    busiest_day_count: int
+    total_time_minutes: int
 
 # Daily Activity Schemas
 class DailyActivityBase(BaseModel):

--- a/lesson-services/app/services/sr_card_service.py
+++ b/lesson-services/app/services/sr_card_service.py
@@ -1,103 +1,178 @@
-from sqlalchemy.orm import Session
-from typing import List, Optional, Dict
-from uuid import UUID
 from datetime import datetime, timedelta
+from typing import Dict, List, Optional
+from uuid import UUID
 
-# from app.models.progress_models import SRCard
-# from app.schemas.sr_schema import SRCardCreate
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.progress_models import SRCard
+from app.schemas.progress_schema import SRCardCreate
+
 
 class SRCardService:
     def __init__(self, db: Session):
         self.db = db
-    
-    # get_user_cards(user_id: UUID, suspended: Optional[bool] = None, due_only: bool = False) -> List[SRCard]
-    # Logic: Get user's SR cards with filters
-    # - Query sr_cards by user_id
-    # - Apply suspended filter if provided
-    # - If due_only=True, filter where due_at <= now and suspended=False
-    # - Return list of cards
-    
-    # get_due_cards(user_id: UUID) -> List[SRCard]
-    # Logic: Get cards due for review
-    # - Query sr_cards by user_id
-    # - Filter: due_at <= current_time AND suspended = false
-    # - Order by due_at ASC (most overdue first)
-    # - Return list of due cards ready for review
-    
-    # create_card(user_id: UUID, flashcard_id: UUID) -> SRCard
-    # Logic: Create new SR card with default SRS parameters
-    # - Check if card already exists for user+flashcard combination
-    # - If exists, return existing card
-    # - Generate new UUID for card id
-    # - Initialize SM-2 algorithm defaults:
-    #   - ease_factor = 2.5 (standard starting difficulty)
-    #   - interval_d = 0 (new card, due today)
-    #   - repetition = 0 (never reviewed)
-    #   - due_at = current timestamp (immediately available)
-    #   - suspended = false
-    # - Insert into database and commit
-    # - Return created card
-    
-    # get_card(card_id: UUID) -> Optional[SRCard]
-    # Logic: Get specific SR card by ID
-    # - Query sr_cards by card_id
-    # - Return card object or None
-    
-    # suspend_card(card_id: UUID) -> Optional[SRCard]
-    # Logic: Suspend card from review rotation
-    # - Find card by card_id
-    # - Update suspended = true
-    # - Commit transaction
-    # - Return updated card
-    
-    # unsuspend_card(card_id: UUID) -> Optional[SRCard]
-    # Logic: Reactivate suspended card
-    # - Find card by card_id
-    # - Update suspended = false
-    # - Commit transaction
-    # - Return updated card
-    
-    # update_card_after_review(card_id: UUID, quality: int) -> SRCard
-    # Logic: Update SR card after review using SM-2 algorithm
-    # - Find card by card_id
-    # - Apply SM-2 spaced repetition algorithm:
-    #   - If quality >= 3 (correct):
-    #     - If repetition == 0: interval = 1 day
-    #     - If repetition == 1: interval = 6 days
-    #     - If repetition >= 2: interval = previous_interval * ease_factor
-    #     - Increment repetition
-    #   - If quality < 3 (incorrect):
-    #     - Reset repetition = 0
-    #     - Reset interval = 0 (due today)
-    #   - Update ease_factor:
-    #     - new_ef = old_ef + (0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02))
-    #     - Clamp ease_factor to minimum 1.3
-    # - Calculate new due_at = current_time + interval_d days
-    # - Update card with new values
-    # - Commit transaction
-    # - Return updated card
-    
-    # delete_card(card_id: UUID) -> bool
-    # Logic: Delete SR card from user's deck
-    # - Find and delete sr_card record
-    # - Keep sr_reviews for historical data
-    # - Commit transaction
-    # - Return True if successful
-    
-    # get_user_stats(user_id: UUID) -> Dict
-    # Logic: Calculate SRS statistics for user
-    # - Count total cards (not suspended)
-    # - Count due cards (due_at <= now, not suspended)
-    # - Count suspended cards
-    # - Count new cards (repetition == 0)
-    # - Count learning cards (repetition < 3)
-    # - Count mature cards (repetition >= 3)
-    # - Calculate average ease_factor
-    # - Calculate average interval
-    # - Return comprehensive statistics dictionary
-    
-    # get_card_by_flashcard(user_id: UUID, flashcard_id: UUID) -> Optional[SRCard]
-    # Logic: Get SR card for specific flashcard
-    # - Query by user_id and flashcard_id
-    # - Return card or None if not found
 
+    def get_user_cards(
+        self,
+        user_id: UUID,
+        suspended: Optional[bool] = None,
+        due_only: bool = False,
+    ) -> List[SRCard]:
+        query = self.db.query(SRCard).filter(SRCard.user_id == user_id)
+
+        if suspended is not None:
+            query = query.filter(SRCard.suspended == suspended)
+
+        if due_only:
+            now = datetime.utcnow()
+            query = query.filter(
+                SRCard.due_at <= now,
+                SRCard.suspended.is_(False),
+            )
+
+        return query.order_by(SRCard.due_at.asc()).all()
+
+    def get_due_cards(self, user_id: UUID) -> List[SRCard]:
+        return self.get_user_cards(user_id=user_id, due_only=True)
+
+    def create_card(self, card_data: SRCardCreate) -> SRCard:
+        existing = self.get_card_by_flashcard(card_data.user_id, card_data.flashcard_id)
+        if existing:
+            return existing
+
+        payload = card_data.model_dump()
+        card = SRCard(**payload)
+        card.due_at = datetime.utcnow()
+
+        self.db.add(card)
+        self.db.commit()
+        self.db.refresh(card)
+        return card
+
+    def get_card(self, card_id: UUID) -> Optional[SRCard]:
+        return self.db.query(SRCard).filter(SRCard.id == card_id).one_or_none()
+
+    def suspend_card(self, card_id: UUID) -> Optional[SRCard]:
+        card = self.get_card(card_id)
+        if not card:
+            return None
+
+        card.suspended = True
+        self.db.commit()
+        self.db.refresh(card)
+        return card
+
+    def unsuspend_card(self, card_id: UUID) -> Optional[SRCard]:
+        card = self.get_card(card_id)
+        if not card:
+            return None
+
+        card.suspended = False
+        self.db.commit()
+        self.db.refresh(card)
+        return card
+
+    def update_card_after_review(self, card_id: UUID, quality: int) -> Optional[SRCard]:
+        card = self.get_card(card_id)
+        if not card:
+            return None
+
+        quality = max(0, min(5, quality))
+        now = datetime.utcnow()
+
+        if quality >= 3:
+            if card.repetition == 0:
+                interval = 1
+            elif card.repetition == 1:
+                interval = 6
+            else:
+                interval = max(1, round(card.interval_d * card.ease_factor))
+            card.repetition += 1
+            card.interval_d = int(interval)
+        else:
+            card.repetition = 0
+            card.interval_d = 0
+
+        new_ef = card.ease_factor + (
+            0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02)
+        )
+        card.ease_factor = max(1.3, round(new_ef, 2))
+
+        card.due_at = now + timedelta(days=card.interval_d)
+        card.suspended = False
+
+        self.db.commit()
+        self.db.refresh(card)
+        return card
+
+    def delete_card(self, card_id: UUID) -> bool:
+        card = self.get_card(card_id)
+        if not card:
+            return False
+
+        self.db.delete(card)
+        self.db.commit()
+        return True
+
+    def get_user_stats(self, user_id: UUID) -> Dict[str, float]:
+        now = datetime.utcnow()
+        base_query = self.db.query(SRCard).filter(SRCard.user_id == user_id)
+
+        total_cards = base_query.count()
+        suspended_cards = base_query.filter(SRCard.suspended.is_(True)).count()
+        due_cards = (
+            base_query.filter(SRCard.suspended.is_(False))
+            .filter(SRCard.due_at <= now)
+            .count()
+        )
+        new_cards = (
+            base_query.filter(SRCard.repetition == 0, SRCard.suspended.is_(False)).count()
+        )
+        learning_cards = (
+            base_query.filter(
+                SRCard.repetition > 0,
+                SRCard.repetition < 3,
+                SRCard.suspended.is_(False),
+            ).count()
+        )
+        mature_cards = (
+            base_query.filter(
+                SRCard.repetition >= 3,
+                SRCard.suspended.is_(False),
+            ).count()
+        )
+
+        avg_ease = (
+            self.db.query(func.avg(SRCard.ease_factor))
+            .filter(SRCard.user_id == user_id, SRCard.suspended.is_(False))
+            .scalar()
+        )
+        avg_interval = (
+            self.db.query(func.avg(SRCard.interval_d))
+            .filter(SRCard.user_id == user_id, SRCard.suspended.is_(False))
+            .scalar()
+        )
+
+        return {
+            "total_cards": total_cards,
+            "due_cards": due_cards,
+            "suspended_cards": suspended_cards,
+            "new_cards": new_cards,
+            "learning_cards": learning_cards,
+            "mature_cards": mature_cards,
+            "average_ease_factor": float(avg_ease or 0.0),
+            "average_interval": float(avg_interval or 0.0),
+        }
+
+    def get_card_by_flashcard(
+        self, user_id: UUID, flashcard_id: UUID
+    ) -> Optional[SRCard]:
+        return (
+            self.db.query(SRCard)
+            .filter(
+                SRCard.user_id == user_id,
+                SRCard.flashcard_id == flashcard_id,
+            )
+            .one_or_none()
+        )

--- a/lesson-services/app/services/sr_review_service.py
+++ b/lesson-services/app/services/sr_review_service.py
@@ -1,100 +1,244 @@
-from sqlalchemy.orm import Session
-from typing import List, Optional, Dict
+from datetime import date, datetime, timedelta
+from typing import Dict, List, Optional
 from uuid import UUID
-from datetime import datetime, date, timedelta
 
-# from app.models.progress_models import SRReview, SRCard
-# from app.schemas.sr_schema import SRReviewCreate
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.progress_models import SRReview
+from app.schemas.progress_schema import SRCardCreate, SRReviewCreate
+from app.services.daily_activity_service import DailyActivityService
+from app.services.sr_card_service import SRCardService
+
+REVIEW_MINUTES_PER_CARD = 2
+REVIEW_POINTS = 5
+
 
 class SRReviewService:
     def __init__(self, db: Session):
         self.db = db
-    
-    # create_review(user_id: UUID, flashcard_id: UUID, quality: int) -> SRReview
-    # Logic: Record flashcard review and update SR card
-    # - Validate quality is between 0-5
-    # - Find SR card by user_id + flashcard_id
-    # - If card doesn't exist, create new card first
-    # - Capture current card state (prev_interval = card.interval_d)
-    # - Generate new UUID for review id
-    # - Set reviewed_at = current timestamp
-    # - Call SR card service to update card based on quality
-    # - Capture new card state (new_interval, new_ef)
-    # - Create sr_review record with:
-    #   - user_id, flashcard_id, quality
-    #   - prev_interval (before update)
-    #   - new_interval (after update)
-    #   - new_ef (new ease factor)
-    #   - reviewed_at timestamp
-    # - Insert review record and commit
-    # - Update daily_activity: increment minutes (estimate ~2 mins per review)
-    # - Update daily_activity: add points (e.g., 5 points per review)
-    # - Return created review record
-    
-    # get_user_reviews(user_id: UUID, limit: int = 100, offset: int = 0, date_from: Optional[date] = None, date_to: Optional[date] = None) -> List[SRReview]
-    # Logic: Get paginated review history for user
-    # - Query sr_reviews by user_id
-    # - Apply date range filters if provided
-    # - Order by reviewed_at DESC
-    # - Apply pagination (limit, offset)
-    # - Return list of review records
-    
-    # get_flashcard_reviews(user_id: UUID, flashcard_id: UUID) -> List[SRReview]
-    # Logic: Get review history for specific flashcard
-    # - Query sr_reviews by user_id and flashcard_id
-    # - Order by reviewed_at DESC
-    # - Return list showing learning progress over time
-    
-    # get_today_reviews(user_id: UUID) -> List[SRReview]
-    # Logic: Get today's review activity
-    # - Calculate start_of_today = midnight today
-    # - Query reviews where reviewed_at >= start_of_today
-    # - Filter by user_id
-    # - Return list of today's reviews
-    
-    # get_today_stats(user_id: UUID) -> Dict
-    # Logic: Calculate today's review statistics
-    # - Get today's reviews
-    # - Count total reviews
-    # - Calculate average quality
-    # - Group count by quality rating (0-5)
-    # - Calculate retention rate (quality >= 3 count / total)
-    # - Return statistics dictionary
-    
-    # get_user_review_stats(user_id: UUID) -> Dict
-    # Logic: Get comprehensive review statistics
-    # - Count total reviews all time
-    # - Calculate average quality score
-    # - Count reviews by quality (distribution 0-5)
-    # - Calculate retention rate (quality >= 3)
-    # - Count unique flashcards reviewed
-    # - Calculate review streak:
-    #   - Query distinct review dates
-    #   - Count consecutive days from today backward
-    # - Get busiest review day (date with most reviews)
-    # - Calculate total time spent (reviews * avg_time_per_review)
-    # - Return comprehensive statistics dictionary
-    
-    # delete_review(review_id: UUID) -> bool
-    # Logic: Delete review record
-    # - Note: This is for data cleanup only
-    # - Warning: Does not revert SR card state
-    # - Find and delete sr_review record
-    # - Commit transaction
-    # - Return True if successful
-    
-    # get_review_streak(user_id: UUID) -> int
-    # Logic: Calculate consecutive days reviewed
-    # - Query distinct dates from sr_reviews for user
-    # - Order by reviewed_at DESC
-    # - Start from today and count backward
-    # - Stop when gap of more than 1 day found
-    # - Return streak length in days
-    
-    # get_review_calendar(user_id: UUID, year: int, month: int) -> Dict[date, int]
-    # Logic: Get review activity calendar for month
-    # - Query reviews for specified month/year
-    # - Group by date
-    # - Count reviews per day
-    # - Return dictionary: {date: review_count}
+        self.card_service = SRCardService(db)
+        self.activity_service = DailyActivityService(db)
 
+    def create_review(self, review_data: SRReviewCreate) -> SRReview:
+        quality = review_data.quality
+        if quality < 0 or quality > 5:
+            raise ValueError("Quality must be between 0 and 5")
+
+        card = self.card_service.get_card_by_flashcard(
+            review_data.user_id, review_data.flashcard_id
+        )
+        if card is None:
+            card = self.card_service.create_card(
+                SRCardCreate(
+                    user_id=review_data.user_id,
+                    flashcard_id=review_data.flashcard_id,
+                )
+            )
+
+        prev_interval = card.interval_d
+        updated_card = self.card_service.update_card_after_review(card.id, quality)
+        if updated_card is None:
+            raise ValueError("Unable to update spaced repetition card")
+
+        review = SRReview(
+            user_id=review_data.user_id,
+            flashcard_id=review_data.flashcard_id,
+            quality=quality,
+            prev_interval=prev_interval,
+            new_interval=updated_card.interval_d,
+            new_ef=updated_card.ease_factor,
+            reviewed_at=datetime.utcnow(),
+        )
+
+        self.db.add(review)
+        self.db.flush()
+
+        today = review.reviewed_at.date()
+        self.activity_service.increment_activity(
+            review.user_id, today, "minutes", REVIEW_MINUTES_PER_CARD
+        )
+        self.activity_service.increment_activity(
+            review.user_id, today, "points", REVIEW_POINTS
+        )
+
+        self.db.refresh(review)
+        return review
+
+    def get_user_reviews(
+        self,
+        user_id: UUID,
+        limit: int = 100,
+        offset: int = 0,
+        date_from: Optional[date] = None,
+        date_to: Optional[date] = None,
+    ) -> List[SRReview]:
+        query = self.db.query(SRReview).filter(SRReview.user_id == user_id)
+
+        if date_from:
+            start = datetime.combine(date_from, datetime.min.time())
+            query = query.filter(SRReview.reviewed_at >= start)
+        if date_to:
+            end = datetime.combine(date_to + timedelta(days=1), datetime.min.time())
+            query = query.filter(SRReview.reviewed_at < end)
+
+        return (
+            query.order_by(SRReview.reviewed_at.desc())
+            .offset(offset)
+            .limit(limit)
+            .all()
+        )
+
+    def get_flashcard_reviews(
+        self, user_id: UUID, flashcard_id: UUID
+    ) -> List[SRReview]:
+        return (
+            self.db.query(SRReview)
+            .filter(
+                SRReview.user_id == user_id,
+                SRReview.flashcard_id == flashcard_id,
+            )
+            .order_by(SRReview.reviewed_at.desc())
+            .all()
+        )
+
+    def get_today_reviews(self, user_id: UUID) -> List[SRReview]:
+        start_of_day = datetime.combine(date.today(), datetime.min.time())
+        end_of_day = start_of_day + timedelta(days=1)
+        return (
+            self.db.query(SRReview)
+            .filter(
+                SRReview.user_id == user_id,
+                SRReview.reviewed_at >= start_of_day,
+                SRReview.reviewed_at < end_of_day,
+            )
+            .order_by(SRReview.reviewed_at.desc())
+            .all()
+        )
+
+    def get_today_stats(self, user_id: UUID) -> Dict[str, object]:
+        reviews = self.get_today_reviews(user_id)
+        return self._calculate_review_stats(reviews)
+
+    def get_user_review_stats(self, user_id: UUID) -> Dict[str, object]:
+        reviews = (
+            self.db.query(SRReview)
+            .filter(SRReview.user_id == user_id)
+            .order_by(SRReview.reviewed_at.desc())
+            .all()
+        )
+        stats = self._calculate_review_stats(reviews)
+        stats["review_streak"] = self.get_review_streak(user_id)
+        stats["unique_flashcards"] = (
+            self.db.query(func.count(func.distinct(SRReview.flashcard_id)))
+            .filter(SRReview.user_id == user_id)
+            .scalar()
+            or 0
+        )
+
+        busiest = (
+            self.db.query(
+                func.date(SRReview.reviewed_at).label("review_date"),
+                func.count(SRReview.id).label("review_count"),
+            )
+            .filter(SRReview.user_id == user_id)
+            .group_by("review_date")
+            .order_by(func.count(SRReview.id).desc(), func.date(SRReview.reviewed_at).desc())
+            .first()
+        )
+        if busiest:
+            stats["busiest_day"] = busiest.review_date
+            stats["busiest_day_count"] = busiest.review_count
+        else:
+            stats["busiest_day"] = None
+            stats["busiest_day_count"] = 0
+
+        stats["total_time_minutes"] = stats["total_reviews"] * REVIEW_MINUTES_PER_CARD
+        return stats
+
+    def delete_review(self, review_id: UUID) -> bool:
+        review = self.db.query(SRReview).filter(SRReview.id == review_id).one_or_none()
+        if review is None:
+            return False
+
+        self.db.delete(review)
+        self.db.commit()
+        return True
+
+    def get_review_streak(self, user_id: UUID) -> int:
+        distinct_dates = (
+            self.db.query(func.date(SRReview.reviewed_at))
+            .filter(SRReview.user_id == user_id)
+            .distinct()
+            .order_by(func.date(SRReview.reviewed_at).desc())
+            .all()
+        )
+
+        today = date.today()
+        streak = 0
+        expected = today
+
+        for (review_date,) in distinct_dates:
+            if review_date == expected:
+                streak += 1
+                expected = expected - timedelta(days=1)
+            elif review_date < expected:
+                break
+
+        return streak
+
+    def get_review_calendar(
+        self, user_id: UUID, year: int, month: int
+    ) -> Dict[date, int]:
+        start = date(year, month, 1)
+        if month == 12:
+            end = date(year + 1, 1, 1)
+        else:
+            end = date(year, month + 1, 1)
+
+        results = (
+            self.db.query(
+                func.date(SRReview.reviewed_at).label("review_date"),
+                func.count(SRReview.id).label("review_count"),
+            )
+            .filter(
+                SRReview.user_id == user_id,
+                SRReview.reviewed_at >= datetime.combine(start, datetime.min.time()),
+                SRReview.reviewed_at < datetime.combine(end, datetime.min.time()),
+            )
+            .group_by("review_date")
+            .all()
+        )
+
+        return {row.review_date: row.review_count for row in results}
+
+    def _calculate_review_stats(self, reviews: List[SRReview]) -> Dict[str, object]:
+        total_reviews = len(reviews)
+        if total_reviews == 0:
+            return {
+                "total_reviews": 0,
+                "average_quality": 0.0,
+                "quality_distribution": {i: 0 for i in range(6)},
+                "retention_rate": 0.0,
+            }
+
+        quality_distribution = {i: 0 for i in range(6)}
+        total_quality = 0
+        retained = 0
+
+        for review in reviews:
+            score = int(review.quality)
+            quality_distribution[score] = quality_distribution.get(score, 0) + 1
+            total_quality += score
+            if score >= 3:
+                retained += 1
+
+        average_quality = total_quality / total_reviews
+        retention_rate = retained / total_reviews if total_reviews else 0.0
+
+        return {
+            "total_reviews": total_reviews,
+            "average_quality": round(average_quality, 2),
+            "quality_distribution": quality_distribution,
+            "retention_rate": round(retention_rate, 2),
+        }


### PR DESCRIPTION
## Summary
- flesh out spaced repetition card router with full CRUD, due, and stats endpoints
- implement spaced repetition review router for history, flashcard details, and aggregated stats
- add supporting schemas and service logic for card scheduling and review analytics

## Testing
- python -m compileall lesson-services/app

------
https://chatgpt.com/codex/tasks/task_b_68e0bab3b4f0832a927cdc5c6ac048a2