### PR TITLE
Add GraphQL proxy support to BFF content service

### DIFF
--- a/bff-services/internal/api/controllers/content_controller.go
+++ b/bff-services/internal/api/controllers/content_controller.go
@@ -111,3 +111,22 @@ func (c *ContentController) GetQuizzes(ctx *gin.Context) {
 
 	respondWithServiceResponse(ctx, resp)
 }
+
+// ProxyGraphQL forwards arbitrary GraphQL requests to the content service.
+func (c *ContentController) ProxyGraphQL(ctx *gin.Context) {
+	token := getOptionalBearerToken(ctx)
+
+	var payload dto.GraphQLRequest
+	if err := ctx.ShouldBindJSON(&payload); err != nil {
+		utils.Fail(ctx, "Invalid GraphQL request", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := c.contentService.ExecuteGraphQL(ctx.Request.Context(), token, payload)
+	if err != nil {
+		utils.Fail(ctx, "Unable to execute GraphQL request", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(ctx, resp)
+}

--- a/bff-services/internal/api/dto/content_dto.go
+++ b/bff-services/internal/api/dto/content_dto.go
@@ -32,3 +32,10 @@ type QuizQueryParams struct {
 	Page     int    `form:"page,default=1"`
 	PageSize int    `form:"pageSize,default=10"`
 }
+
+// GraphQLRequest represents a GraphQL operation forwarded to the content service.
+type GraphQLRequest struct {
+	Query         string                 `json:"query" binding:"required"`
+	OperationName string                 `json:"operationName,omitempty"`
+	Variables     map[string]interface{} `json:"variables,omitempty"`
+}

--- a/bff-services/internal/server/router.go
+++ b/bff-services/internal/server/router.go
@@ -91,6 +91,7 @@ func NewRouter(deps Deps) *gin.Engine {
 		if contentCtrl != nil {
 			content := api.Group("/content")
 			{
+				content.POST("/graphql", contentCtrl.ProxyGraphQL)
 				content.GET("/metadata", contentCtrl.GetTopicsLevelsTags)
 				content.GET("/lessons", contentCtrl.GetLessons)
 				content.POST("/lessons", contentCtrl.CreateLesson)


### PR DESCRIPTION
## Summary
- add a generic GraphQL proxy endpoint to the BFF content API
- expose the proxy through the router and DTOs for forwarding arbitrary operations
- refactor the content service client to reuse a shared GraphQL request helper

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68e1ff3696a8832a8789730d2bf10fdb