### PR TITLE
Add notification template API endpoints

### DIFF
--- a/notification-services/src/routes/emailRoutes.ts
+++ b/notification-services/src/routes/emailRoutes.ts
@@ -1,11 +1,28 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { EmailService } from '../email/EmailService';
+import { NotificationTemplateService } from '../services/notificationTemplates';
 
 export const router = Router();
 
 router.get('/health', (_req, res) => {
   res.json({ status: 'ok' });
+});
+
+const templateService = new NotificationTemplateService();
+
+router.get('/notification-templates', async (_req, res) => {
+  const templates = await templateService.listTemplates();
+  res.json({ data: templates });
+});
+
+router.get('/notification-templates/:id', async (req, res) => {
+  const template = await templateService.getTemplateById(req.params.id);
+  if (!template) {
+    return res.status(404).json({ error: 'Template not found' });
+  }
+
+  res.json({ data: template });
 });
 
 const EmailSchema = z.object({

--- a/notification-services/src/services/notificationTemplates.ts
+++ b/notification-services/src/services/notificationTemplates.ts
@@ -1,0 +1,52 @@
+export interface NotificationTemplate {
+  id: string;
+  name: string;
+  description: string;
+  subject: string;
+  body: string;
+  placeholders: string[];
+  updated_at: string;
+}
+
+const mockNotificationTemplates: NotificationTemplate[] = [
+  {
+    id: 'welcome',
+    name: 'Welcome Email',
+    description: 'Sent to new users when they join the platform.',
+    subject: 'Welcome to LearnHub!',
+    body:
+      "Hi {{user_name}},\n\nWe're excited to have you at LearnHub. Start exploring courses that match your goals today!\n\nHappy learning,\nThe LearnHub Team",
+    placeholders: ['user_name'],
+    updated_at: '2024-10-01T12:00:00Z',
+  },
+  {
+    id: 'course-update',
+    name: 'Course Update',
+    description: 'Notify learners when new lessons are added to a course they follow.',
+    subject: "New lesson available: {{lesson_title}}",
+    body:
+      "Hello {{user_name}},\n\nA new lesson '{{lesson_title}}' has just been published in {{course_title}}. Jump back in and continue your progress!\n\nView the lesson: {{lesson_url}}\n\nBest regards,\nLearnHub Team",
+    placeholders: ['user_name', 'lesson_title', 'course_title', 'lesson_url'],
+    updated_at: '2024-10-05T09:30:00Z',
+  },
+  {
+    id: 'deadline-reminder',
+    name: 'Deadline Reminder',
+    description: 'Friendly reminder to complete upcoming assignments or quizzes.',
+    subject: 'Reminder: {{item_title}} is due soon',
+    body:
+      "Hi {{user_name}},\n\nThis is a quick reminder that {{item_title}} is due on {{due_date}}. Stay on track and submit before the deadline!\n\nNeed help? Reply to this email and our team will assist you.\n\nThanks,\nLearnHub Support",
+    placeholders: ['user_name', 'item_title', 'due_date'],
+    updated_at: '2024-10-07T16:45:00Z',
+  },
+];
+
+export class NotificationTemplateService {
+  async listTemplates(): Promise<NotificationTemplate[]> {
+    return mockNotificationTemplates;
+  }
+
+  async getTemplateById(id: string): Promise<NotificationTemplate | undefined> {
+    return mockNotificationTemplates.find((template) => template.id === id);
+  }
+}


### PR DESCRIPTION
## Summary
- add a notification template service that serves mock template data
- expose routes to list all templates and fetch a template by id

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e5e62b5ab8832a8681d76b606695e3