### PR TITLE
Implement role management endpoints and integrate BFF role updates

### DIFF
--- a/bff-services/internal/api/controllers/user_controller.go
+++ b/bff-services/internal/api/controllers/user_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"sync"
 
 	"bff-services/internal/api/dto"
@@ -128,6 +129,78 @@ func (u *UserController) UpdateProfile(c *gin.Context) {
 }
 
 // Users management methods
+func (u *UserController) AssignRoleToUser(ctx *gin.Context) {
+	actorID, actorEmail, sessionID, ok := getUserContextFromMiddleware(ctx)
+	if !ok {
+		return
+	}
+
+	targetUserID := ctx.Param("id")
+	if targetUserID == "" {
+		utils.Fail(ctx, "User ID is required", http.StatusBadRequest, "missing user ID")
+		return
+	}
+	if _, err := uuid.Parse(targetUserID); err != nil {
+		utils.Fail(ctx, "Invalid user ID", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	var req dto.UserRoleRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		utils.Fail(ctx, "Invalid request data", http.StatusBadRequest, err.Error())
+		return
+	}
+	req.RoleName = strings.TrimSpace(req.RoleName)
+	if req.RoleName == "" {
+		utils.Fail(ctx, "Role name is required", http.StatusBadRequest, "role_name is required")
+		return
+	}
+
+	resp, err := u.userService.AssignRoleWithContext(ctx.Request.Context(), actorID, actorEmail, sessionID, targetUserID, req)
+	if err != nil {
+		utils.Fail(ctx, "Failed to assign role", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(ctx, resp)
+}
+
+func (u *UserController) RemoveRoleFromUser(ctx *gin.Context) {
+	actorID, actorEmail, sessionID, ok := getUserContextFromMiddleware(ctx)
+	if !ok {
+		return
+	}
+
+	targetUserID := ctx.Param("id")
+	if targetUserID == "" {
+		utils.Fail(ctx, "User ID is required", http.StatusBadRequest, "missing user ID")
+		return
+	}
+	if _, err := uuid.Parse(targetUserID); err != nil {
+		utils.Fail(ctx, "Invalid user ID", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	var req dto.UserRoleRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		utils.Fail(ctx, "Invalid request data", http.StatusBadRequest, err.Error())
+		return
+	}
+	req.RoleName = strings.TrimSpace(req.RoleName)
+	if req.RoleName == "" {
+		utils.Fail(ctx, "Role name is required", http.StatusBadRequest, "role_name is required")
+		return
+	}
+
+	resp, err := u.userService.RemoveRoleWithContext(ctx.Request.Context(), actorID, actorEmail, sessionID, targetUserID, req)
+	if err != nil {
+		utils.Fail(ctx, "Failed to remove role", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(ctx, resp)
+}
+
 func (u *UserController) ListUsersWithProgress(ctx *gin.Context) {
 	// Get query parameters
 	page := ctx.DefaultQuery("page", "1")

--- a/bff-services/internal/api/dto/user_dto.go
+++ b/bff-services/internal/api/dto/user_dto.go
@@ -23,6 +23,10 @@ type UserProfile struct {
 	AvatarURL   string `json:"avatar_url"`
 }
 
+type UserRoleRequest struct {
+	RoleName string `json:"role_name" binding:"required"`
+}
+
 type UserData struct {
 	ID            string       `json:"id"`
 	Email         string       `json:"email"`

--- a/bff-services/internal/routes/user_routes.go
+++ b/bff-services/internal/routes/user_routes.go
@@ -15,13 +15,15 @@ func SetupUserRoutes(api *gin.RouterGroup, controllers *controllers.Controllers,
 	}
 
 	// Public user routes
-	
+
 	// Protected user routes
 	if sessionCache != nil {
 		users := api.Group("/users")
 		users.Use(middleware.AuthRequired(sessionCache))
 		{
 			users.GET("", controllers.User.ListUsersWithProgress)
+			users.POST("/:id/roles", controllers.User.AssignRoleToUser)
+			users.DELETE("/:id/roles", controllers.User.RemoveRoleFromUser)
 			// Register specific routes before parameterized routes
 			users.GET("/:id", controllers.User.GetUserById)
 		}

--- a/bff-services/internal/services/user_service.go
+++ b/bff-services/internal/services/user_service.go
@@ -33,6 +33,8 @@ type UserService interface {
 	// New methods for internal communication with user context
 	GetProfileWithContext(ctx context.Context, userID, email, sessionID string) (*HTTPResponse, error)
 	UpdateProfileWithContext(ctx context.Context, userID, email, sessionID string, payload dto.UpdateProfileRequest) (*HTTPResponse, error)
+	AssignRoleWithContext(ctx context.Context, actorUserID, actorEmail, actorSessionID, userID string, payload dto.UserRoleRequest) (*HTTPResponse, error)
+	RemoveRoleWithContext(ctx context.Context, actorUserID, actorEmail, actorSessionID, userID string, payload dto.UserRoleRequest) (*HTTPResponse, error)
 }
 
 type UserServiceClient struct {
@@ -84,7 +86,6 @@ func (c *UserServiceClient) VerifyEmail(ctx context.Context, token string) (*HTT
 	path := "/api/v1/users/verify-email?token=" + url.QueryEscape(token)
 	return c.doRequest(ctx, http.MethodGet, path, nil, nil)
 }
-
 
 func (c *UserServiceClient) RequestPasswordReset(ctx context.Context, payload dto.PasswordResetRequest) (*HTTPResponse, error) {
 	return c.doRequest(ctx, http.MethodPost, "/api/v1/users/password/reset/request", payload, nil)
@@ -227,4 +228,14 @@ func (c *UserServiceClient) GetProfileWithContext(ctx context.Context, userID, e
 
 func (c *UserServiceClient) UpdateProfileWithContext(ctx context.Context, userID, email, sessionID string, payload dto.UpdateProfileRequest) (*HTTPResponse, error) {
 	return c.doRequest(ctx, http.MethodPut, "/api/v1/users/profile", payload, internalAuthHeaders(userID, email, sessionID))
+}
+
+func (c *UserServiceClient) AssignRoleWithContext(ctx context.Context, actorUserID, actorEmail, actorSessionID, userID string, payload dto.UserRoleRequest) (*HTTPResponse, error) {
+	path := fmt.Sprintf("/api/v1/users/%s/roles", userID)
+	return c.doRequest(ctx, http.MethodPost, path, payload, internalAuthHeaders(actorUserID, actorEmail, actorSessionID))
+}
+
+func (c *UserServiceClient) RemoveRoleWithContext(ctx context.Context, actorUserID, actorEmail, actorSessionID, userID string, payload dto.UserRoleRequest) (*HTTPResponse, error) {
+	path := fmt.Sprintf("/api/v1/users/%s/roles", userID)
+	return c.doRequest(ctx, http.MethodDelete, path, payload, internalAuthHeaders(actorUserID, actorEmail, actorSessionID))
 }

--- a/user-services/internal/api/controllers/role_controller.go
+++ b/user-services/internal/api/controllers/role_controller.go
@@ -1,9 +1,14 @@
 package controllers
 
 import (
+	"net/http"
+
+	"user-services/internal/api/dto"
 	"user-services/internal/api/services"
+	"user-services/internal/utils"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 )
 
 type RoleController struct {
@@ -25,7 +30,28 @@ func NewRoleController(roleService services.RoleService) *RoleController {
 // @Success 201 {object} dto.RoleResponse
 // @Router /roles [post]
 func (c *RoleController) CreateRole(ctx *gin.Context) {
-	// TODO: implement
+	var req dto.CreateRoleRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		utils.Fail(ctx, "Invalid role payload", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	role, err := c.roleService.CreateRole(ctx.Request.Context(), req.Name)
+	if err != nil {
+		switch err {
+		case services.ErrInvalidRoleName:
+			utils.Fail(ctx, "Role name is required", http.StatusBadRequest, err.Error())
+			return
+		case services.ErrRoleAlreadyExists:
+			utils.Fail(ctx, "Role already exists", http.StatusConflict, err.Error())
+			return
+		default:
+			utils.Fail(ctx, "Failed to create role", http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+
+	utils.Created(ctx, role)
 }
 
 // GetAllRoles godoc
@@ -35,7 +61,13 @@ func (c *RoleController) CreateRole(ctx *gin.Context) {
 // @Success 200 {array} dto.RoleResponse
 // @Router /roles [get]
 func (c *RoleController) GetAllRoles(ctx *gin.Context) {
-	// TODO: implement
+	roles, err := c.roleService.GetAllRoles(ctx.Request.Context())
+	if err != nil {
+		utils.Fail(ctx, "Failed to fetch roles", http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	utils.Success(ctx, roles)
 }
 
 // DeleteRole godoc
@@ -45,7 +77,23 @@ func (c *RoleController) GetAllRoles(ctx *gin.Context) {
 // @Success 204
 // @Router /roles/{id} [delete]
 func (c *RoleController) DeleteRole(ctx *gin.Context) {
-	// TODO: implement
+	roleIDParam := ctx.Param("id")
+	roleID, err := uuid.Parse(roleIDParam)
+	if err != nil {
+		utils.Fail(ctx, "Invalid role ID", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := c.roleService.DeleteRole(ctx.Request.Context(), roleID); err != nil {
+		if err == services.ErrRoleNotFound {
+			utils.Fail(ctx, "Role not found", http.StatusNotFound, err.Error())
+			return
+		}
+		utils.Fail(ctx, "Failed to delete role", http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
 }
 
 // AssignRoleToUser godoc
@@ -57,7 +105,34 @@ func (c *RoleController) DeleteRole(ctx *gin.Context) {
 // @Success 200
 // @Router /users/{id}/roles [post]
 func (c *RoleController) AssignRoleToUser(ctx *gin.Context) {
-	// TODO: implement
+	userIDParam := ctx.Param("id")
+	userID, err := uuid.Parse(userIDParam)
+	if err != nil {
+		utils.Fail(ctx, "Invalid user ID", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	var req dto.AssignRoleRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		utils.Fail(ctx, "Invalid request payload", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := c.roleService.AssignRoleToUser(ctx.Request.Context(), userID, req.RoleName); err != nil {
+		switch err {
+		case services.ErrInvalidRoleName:
+			utils.Fail(ctx, "Role name is required", http.StatusBadRequest, err.Error())
+			return
+		case services.ErrRoleNotFound:
+			utils.Fail(ctx, "Role not found", http.StatusNotFound, err.Error())
+			return
+		default:
+			utils.Fail(ctx, "Failed to assign role", http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+
+	utils.Success(ctx, gin.H{"message": "Role assigned successfully"})
 }
 
 // RemoveRoleFromUser godoc
@@ -69,5 +144,35 @@ func (c *RoleController) AssignRoleToUser(ctx *gin.Context) {
 // @Success 200
 // @Router /users/{id}/roles [delete]
 func (c *RoleController) RemoveRoleFromUser(ctx *gin.Context) {
-	// TODO: implement
+	userIDParam := ctx.Param("id")
+	userID, err := uuid.Parse(userIDParam)
+	if err != nil {
+		utils.Fail(ctx, "Invalid user ID", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	var req dto.RemoveRoleRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		utils.Fail(ctx, "Invalid request payload", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := c.roleService.RemoveRoleFromUser(ctx.Request.Context(), userID, req.RoleName); err != nil {
+		switch err {
+		case services.ErrInvalidRoleName:
+			utils.Fail(ctx, "Role name is required", http.StatusBadRequest, err.Error())
+			return
+		case services.ErrRoleNotFound:
+			utils.Fail(ctx, "Role not found", http.StatusNotFound, err.Error())
+			return
+		case services.ErrUserRoleNotFound:
+			utils.Fail(ctx, "User does not have this role", http.StatusNotFound, err.Error())
+			return
+		default:
+			utils.Fail(ctx, "Failed to remove role", http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+
+	utils.Success(ctx, gin.H{"message": "Role removed successfully"})
 }

--- a/user-services/internal/api/repositories/role_repo.go
+++ b/user-services/internal/api/repositories/role_repo.go
@@ -2,10 +2,12 @@ package repositories
 
 import (
 	"context"
+	"strings"
 	"user-services/internal/models"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type RoleRepository interface {
@@ -31,46 +33,91 @@ func NewRoleRepository(db *gorm.DB) RoleRepository {
 }
 
 func (r *roleRepository) Create(ctx context.Context, role *models.Role) error {
-	// TODO: implement
-	return nil
+	return r.db.WithContext(ctx).Create(role).Error
 }
 
 func (r *roleRepository) GetByID(ctx context.Context, id uuid.UUID) (*models.Role, error) {
-	// TODO: implement
-	return nil, nil
+	var role models.Role
+	if err := r.db.WithContext(ctx).First(&role, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+	return &role, nil
 }
 
 func (r *roleRepository) GetByName(ctx context.Context, name string) (*models.Role, error) {
-	// TODO: implement
-	return nil, nil
+	var role models.Role
+	if err := r.db.WithContext(ctx).
+		Where("LOWER(name) = ?", strings.ToLower(name)).
+		First(&role).Error; err != nil {
+		return nil, err
+	}
+	return &role, nil
 }
 
 func (r *roleRepository) GetAll(ctx context.Context) ([]models.Role, error) {
-	// TODO: implement
-	return nil, nil
+	var roles []models.Role
+	if err := r.db.WithContext(ctx).
+		Order("name ASC").
+		Find(&roles).Error; err != nil {
+		return nil, err
+	}
+	return roles, nil
 }
 
 func (r *roleRepository) Delete(ctx context.Context, id uuid.UUID) error {
-	// TODO: implement
+	result := r.db.WithContext(ctx).Delete(&models.Role{}, "id = ?", id)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
 	return nil
 }
 
 func (r *roleRepository) AssignRoleToUser(ctx context.Context, userID, roleID uuid.UUID) error {
-	// TODO: implement
-	return nil
+	userRole := models.UserRole{
+		UserID: userID,
+		RoleID: roleID,
+	}
+	return r.db.WithContext(ctx).
+		Clauses(clause.OnConflict{DoNothing: true}).
+		Create(&userRole).Error
 }
 
 func (r *roleRepository) RemoveRoleFromUser(ctx context.Context, userID, roleID uuid.UUID) error {
-	// TODO: implement
+	result := r.db.WithContext(ctx).
+		Where("user_id = ? AND role_id = ?", userID, roleID).
+		Delete(&models.UserRole{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
 	return nil
 }
 
 func (r *roleRepository) GetUserRoles(ctx context.Context, userID uuid.UUID) ([]models.Role, error) {
-	// TODO: implement
-	return nil, nil
+	var roles []models.Role
+	if err := r.db.WithContext(ctx).
+		Model(&models.Role{}).
+		Joins("JOIN user_roles ON user_roles.role_id = roles.id").
+		Where("user_roles.user_id = ?", userID).
+		Order("roles.name ASC").
+		Find(&roles).Error; err != nil {
+		return nil, err
+	}
+	return roles, nil
 }
 
 func (r *roleRepository) GetRoleUsers(ctx context.Context, roleID uuid.UUID) ([]uuid.UUID, error) {
-	// TODO: implement
-	return nil, nil
+	var userIDs []uuid.UUID
+	if err := r.db.WithContext(ctx).
+		Model(&models.UserRole{}).
+		Where("role_id = ?", roleID).
+		Pluck("user_id", &userIDs).Error; err != nil {
+		return nil, err
+	}
+	return userIDs, nil
 }

--- a/user-services/internal/api/routes/role_routes.go
+++ b/user-services/internal/api/routes/role_routes.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"user-services/internal/api/controllers"
+	"user-services/internal/api/middleware"
 
 	"github.com/gin-gonic/gin"
 )
@@ -9,6 +10,7 @@ import (
 func RegisterRoleRoutes(router *gin.RouterGroup, controller *controllers.RoleController) {
 	// Role management (admin only)
 	roles := router.Group("/roles")
+	roles.Use(middleware.InternalAuthRequired())
 	{
 		roles.POST("", controller.CreateRole)       // POST /roles
 		roles.GET("", controller.GetAllRoles)       // GET /roles
@@ -17,6 +19,7 @@ func RegisterRoleRoutes(router *gin.RouterGroup, controller *controllers.RoleCon
 
 	// User role assignment (admin only)
 	users := router.Group("/users")
+	users.Use(middleware.InternalAuthRequired())
 	{
 		users.POST("/:id/roles", controller.AssignRoleToUser)     // POST /users/:id/roles
 		users.DELETE("/:id/roles", controller.RemoveRoleFromUser) // DELETE /users/:id/roles

--- a/user-services/internal/api/services/role_service.go
+++ b/user-services/internal/api/services/role_service.go
@@ -2,10 +2,21 @@ package services
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"user-services/internal/api/dto"
 	"user-services/internal/api/repositories"
+	"user-services/internal/models"
 
 	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+var (
+	ErrInvalidRoleName   = errors.New("invalid role name")
+	ErrRoleAlreadyExists = errors.New("role already exists")
+	ErrRoleNotFound      = errors.New("role not found")
+	ErrUserRoleNotFound  = errors.New("user role assignment not found")
 )
 
 type RoleService interface {
@@ -31,41 +42,133 @@ func NewRoleService(roleRepo repositories.RoleRepository) RoleService {
 }
 
 func (s *roleService) CreateRole(ctx context.Context, name string) (*dto.RoleResponse, error) {
-	// TODO: implement
-	return nil, nil
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return nil, ErrInvalidRoleName
+	}
+
+	if _, err := s.roleRepo.GetByName(ctx, trimmed); err == nil {
+		return nil, ErrRoleAlreadyExists
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
+	role := &models.Role{Name: trimmed}
+	if err := s.roleRepo.Create(ctx, role); err != nil {
+		return nil, err
+	}
+
+	return &dto.RoleResponse{ID: role.ID, Name: role.Name}, nil
 }
 
 func (s *roleService) GetRoleByName(ctx context.Context, name string) (*dto.RoleResponse, error) {
-	// TODO: implement
-	return nil, nil
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return nil, ErrInvalidRoleName
+	}
+
+	role, err := s.roleRepo.GetByName(ctx, trimmed)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrRoleNotFound
+		}
+		return nil, err
+	}
+
+	return &dto.RoleResponse{ID: role.ID, Name: role.Name}, nil
 }
 
 func (s *roleService) GetAllRoles(ctx context.Context) ([]dto.RoleResponse, error) {
-	// TODO: implement
-	return nil, nil
+	roles, err := s.roleRepo.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	responses := make([]dto.RoleResponse, len(roles))
+	for i, role := range roles {
+		responses[i] = dto.RoleResponse{ID: role.ID, Name: role.Name}
+	}
+	return responses, nil
 }
 
 func (s *roleService) DeleteRole(ctx context.Context, roleID uuid.UUID) error {
-	// TODO: implement
+	if err := s.roleRepo.Delete(ctx, roleID); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrRoleNotFound
+		}
+		return err
+	}
 	return nil
 }
 
 func (s *roleService) AssignRoleToUser(ctx context.Context, userID uuid.UUID, roleName string) error {
-	// TODO: implement
-	return nil
+	trimmed := strings.TrimSpace(roleName)
+	if trimmed == "" {
+		return ErrInvalidRoleName
+	}
+
+	role, err := s.roleRepo.GetByName(ctx, trimmed)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrRoleNotFound
+		}
+		return err
+	}
+
+	return s.roleRepo.AssignRoleToUser(ctx, userID, role.ID)
 }
 
 func (s *roleService) RemoveRoleFromUser(ctx context.Context, userID uuid.UUID, roleName string) error {
-	// TODO: implement
+	trimmed := strings.TrimSpace(roleName)
+	if trimmed == "" {
+		return ErrInvalidRoleName
+	}
+
+	role, err := s.roleRepo.GetByName(ctx, trimmed)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrRoleNotFound
+		}
+		return err
+	}
+
+	if err := s.roleRepo.RemoveRoleFromUser(ctx, userID, role.ID); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrUserRoleNotFound
+		}
+		return err
+	}
 	return nil
 }
 
 func (s *roleService) GetUserRoles(ctx context.Context, userID uuid.UUID) ([]string, error) {
-	// TODO: implement
-	return nil, nil
+	roles, err := s.roleRepo.GetUserRoles(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	roleNames := make([]string, len(roles))
+	for i, role := range roles {
+		roleNames[i] = role.Name
+	}
+	return roleNames, nil
 }
 
 func (s *roleService) CheckUserHasRole(ctx context.Context, userID uuid.UUID, roleName string) (bool, error) {
-	// TODO: implement
+	trimmed := strings.TrimSpace(roleName)
+	if trimmed == "" {
+		return false, ErrInvalidRoleName
+	}
+
+	roles, err := s.roleRepo.GetUserRoles(ctx, userID)
+	if err != nil {
+		return false, err
+	}
+
+	for _, role := range roles {
+		if strings.EqualFold(role.Name, trimmed) {
+			return true, nil
+		}
+	}
 	return false, nil
 }

--- a/user-services/internal/server/router.go
+++ b/user-services/internal/server/router.go
@@ -48,12 +48,15 @@ func NewRouter(deps Deps) *gin.Engine {
 	mfaService := services.NewMFAService(mfaRepo, userRepo)
 	sessionService := services.NewSessionService(sessionRepo, sessionCache)
 	userService := services.NewUserService(userRepo)
+	roleRepo := repositories.NewRoleRepository(deps.DB)
+	roleService := services.NewRoleService(roleRepo)
 
 	// Initialize controllers
 	userCtrl := controllers.NewUserController(authService, profileService, currentUserService, userService)
 	passwordCtrl := controllers.NewPasswordController(passwordService)
 	mfaCtrl := controllers.NewMFAController(mfaService)
 	sessionCtrl := controllers.NewSessionController(sessionService)
+	roleCtrl := controllers.NewRoleController(roleService)
 
 	api := r.Group("/api/v1")
 	{
@@ -61,6 +64,7 @@ func NewRouter(deps Deps) *gin.Engine {
 		routers.RegisterPasswordRoutes(api, passwordCtrl, sessionCache)
 		routers.RegisterMFARoutes(api, mfaCtrl, sessionCache)
 		routers.RegisterSessionRoutes(api, sessionCtrl, sessionCache)
+		routers.RegisterRoleRoutes(api, roleCtrl)
 	}
 
 	return r


### PR DESCRIPTION
## Summary
- implement the role repository, service, and controller logic in the user service and protect the routes with internal auth
- register the role routes in the user service router and expose assignment/removal endpoints
- wire the BFF to call the role APIs by adding DTOs, controller actions, service client helpers, and routes for updating user roles

## Testing
- `go test ./...` *(fails: vendor directory is out of sync with go.mod)*

------
https://chatgpt.com/codex/tasks/task_b_68e763bb3764832a91d90611d0a15f20