### PR TITLE
Add active session info to user profile endpoints

### DIFF
--- a/user-services/internal/api/dto/user_dto.go
+++ b/user-services/internal/api/dto/user_dto.go
@@ -8,18 +8,19 @@ import (
 
 // PublicUser exposed via API (no sensitive data)
 type PublicUser struct {
-	ID            uuid.UUID    `json:"id"`
-	Email         string       `json:"email"`
-	EmailVerified bool         `json:"email_verified"`
-	Status        string       `json:"status"`
-	LastLoginAt   time.Time    `json:"last_login_at,omitempty"`
-	LastLoginIP   string       `json:"last_login_ip,omitempty"`
-	LockoutUntil  time.Time    `json:"lockout_until,omitempty"`
-	DeletedAt     time.Time    `json:"deleted_at,omitempty"`
-	Profile       *UserProfile `json:"profile,omitempty"`
-	Roles         []Role       `json:"roles,omitempty"`
-	CreatedAt     time.Time    `json:"created_at"`
-	UpdatedAt     time.Time    `json:"updated_at"`
+	ID            uuid.UUID         `json:"id"`
+	Email         string            `json:"email"`
+	EmailVerified bool              `json:"email_verified"`
+	Status        string            `json:"status"`
+	LastLoginAt   time.Time         `json:"last_login_at,omitempty"`
+	LastLoginIP   string            `json:"last_login_ip,omitempty"`
+	LockoutUntil  time.Time         `json:"lockout_until,omitempty"`
+	DeletedAt     time.Time         `json:"deleted_at,omitempty"`
+	Profile       *UserProfile      `json:"profile,omitempty"`
+	Roles         []Role            `json:"roles,omitempty"`
+	Sessions      []SessionResponse `json:"sessions,omitempty"`
+	CreatedAt     time.Time         `json:"created_at"`
+	UpdatedAt     time.Time         `json:"updated_at"`
 }
 
 type Role struct {
@@ -29,10 +30,10 @@ type Role struct {
 
 // UserProfile for non-auth data
 type UserProfile struct {
-	DisplayName string `json:"display_name,omitempty"`
-	AvatarURL   string `json:"avatar_url,omitempty"`
-	Locale      string `json:"locale"`
-	TimeZone    string `json:"time_zone"`
+	DisplayName string    `json:"display_name,omitempty"`
+	AvatarURL   string    `json:"avatar_url,omitempty"`
+	Locale      string    `json:"locale"`
+	TimeZone    string    `json:"time_zone"`
 	UpdatedAt   time.Time `json:"updated_at"`
 }
 

--- a/user-services/internal/server/router.go
+++ b/user-services/internal/server/router.go
@@ -52,7 +52,7 @@ func NewRouter(deps Deps) *gin.Engine {
 	roleService := services.NewRoleService(roleRepo)
 
 	// Initialize controllers
-	userCtrl := controllers.NewUserController(authService, profileService, currentUserService, userService)
+	userCtrl := controllers.NewUserController(authService, profileService, currentUserService, userService, sessionService)
 	passwordCtrl := controllers.NewPasswordController(passwordService)
 	mfaCtrl := controllers.NewMFAController(mfaService)
 	sessionCtrl := controllers.NewSessionController(sessionService)


### PR DESCRIPTION
## Summary
- include session service dependency in the user controller to attach active session data to profile and user detail responses
- expose a sessions array in the public user DTO so clients can view login devices and IPs
- wire the session service into the router when constructing the user controller

## Testing
- go test ./... *(fails: inconsistent vendoring reported by Go toolchain)*

------
https://chatgpt.com/codex/tasks/task_b_68e8c4c0362c832aa0298954e7b22fc5