### PR TITLE
Use auth middleware for user-context routes

### DIFF
--- a/lesson-services/app/routers/leaderboard_routes.py
+++ b/lesson-services/app/routers/leaderboard_routes.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy.orm import Session
 
 from app.database.connection import get_db
@@ -85,11 +85,12 @@ def create_monthly_snapshot(
     return {"created": created}
 
 
-@router.get("/user/{user_id}/history", response_model=Dict[str, List[LeaderboardResponse]])
+@router.get("/user/me/history", response_model=Dict[str, List[LeaderboardResponse]])
 def get_user_history(
-    user_id: UUID,
+    request: Request,
     service: LeaderboardService = Depends(get_leaderboard_service),
 ) -> Dict[str, List[LeaderboardResponse]]:
+    user_id: UUID = request.state.user_id
     return service.get_user_leaderboard_history(user_id)
 
 

--- a/lesson-services/app/routers/quiz_attempt_routes.py
+++ b/lesson-services/app/routers/quiz_attempt_routes.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from sqlalchemy.orm import Session
 
 from app.database.connection import get_db
@@ -58,32 +58,35 @@ def submit_quiz_attempt(
     return QuizAttemptDetailResponse.model_validate(refreshed, from_attributes=True)
 
 
-@router.get("/user/{user_id}/quiz/{quiz_id}", response_model=List[QuizAttemptResponse])
+@router.get("/user/me/quiz/{quiz_id}", response_model=List[QuizAttemptResponse])
 def get_user_quiz_attempts(
-    user_id: UUID,
+    request: Request,
     quiz_id: UUID,
     service: QuizAttemptService = Depends(get_quiz_attempt_service),
 ) -> List[QuizAttemptResponse]:
+    user_id: UUID = request.state.user_id
     return service.get_user_quiz_attempts(user_id, quiz_id)
 
 
-@router.get("/user/{user_id}/history", response_model=List[QuizAttemptResponse])
+@router.get("/user/me/history", response_model=List[QuizAttemptResponse])
 def get_user_quiz_history(
-    user_id: UUID,
+    request: Request,
     passed: Optional[bool] = Query(None),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     service: QuizAttemptService = Depends(get_quiz_attempt_service),
 ) -> List[QuizAttemptResponse]:
+    user_id: UUID = request.state.user_id
     return service.get_user_quiz_history(user_id, passed=passed, limit=limit, offset=offset)
 
 
-@router.get("/lesson/{lesson_id}/user/{user_id}", response_model=List[QuizAttemptResponse])
+@router.get("/lesson/{lesson_id}/user/me", response_model=List[QuizAttemptResponse])
 def get_lesson_quiz_attempts(
     lesson_id: UUID,
-    user_id: UUID,
+    request: Request,
     service: QuizAttemptService = Depends(get_quiz_attempt_service),
 ) -> List[QuizAttemptResponse]:
+    user_id: UUID = request.state.user_id
     return service.get_lesson_quiz_attempts(lesson_id, user_id)
 
 

--- a/lesson-services/app/routers/sr_review_routes.py
+++ b/lesson-services/app/routers/sr_review_routes.py
@@ -2,7 +2,7 @@ from datetime import date
 from typing import List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from sqlalchemy.orm import Session
 
 from app.database.connection import get_db
@@ -34,15 +34,16 @@ def create_review(
     return SRReviewResponse.model_validate(review, from_attributes=True)
 
 
-@router.get("/user/{user_id}", response_model=List[SRReviewResponse])
+@router.get("/user/me", response_model=List[SRReviewResponse])
 def get_user_reviews(
-    user_id: UUID,
+    request: Request,
     limit: int = Query(100, ge=1, le=500),
     offset: int = Query(0, ge=0),
     date_from: Optional[date] = Query(None),
     date_to: Optional[date] = Query(None),
     service: SRReviewService = Depends(get_sr_review_service),
 ) -> List[SRReviewResponse]:
+    user_id: UUID = request.state.user_id
     reviews = service.get_user_reviews(
         user_id,
         limit=limit,
@@ -53,30 +54,33 @@ def get_user_reviews(
     return [SRReviewResponse.model_validate(review, from_attributes=True) for review in reviews]
 
 
-@router.get("/user/{user_id}/flashcard/{flashcard_id}", response_model=List[SRReviewResponse])
+@router.get("/user/me/flashcard/{flashcard_id}", response_model=List[SRReviewResponse])
 def get_flashcard_reviews(
-    user_id: UUID,
+    request: Request,
     flashcard_id: UUID,
     service: SRReviewService = Depends(get_sr_review_service),
 ) -> List[SRReviewResponse]:
+    user_id: UUID = request.state.user_id
     reviews = service.get_flashcard_reviews(user_id, flashcard_id)
     return [SRReviewResponse.model_validate(review, from_attributes=True) for review in reviews]
 
 
-@router.get("/user/{user_id}/today", response_model=SRReviewTodayStatsResponse)
+@router.get("/user/me/today", response_model=SRReviewTodayStatsResponse)
 def get_today_review_stats(
-    user_id: UUID, 
+    request: Request,
     service: SRReviewService = Depends(get_sr_review_service)
 ) -> SRReviewTodayStatsResponse:
+    user_id: UUID = request.state.user_id
     stats = service.get_today_stats(user_id)
     return SRReviewTodayStatsResponse(**stats)
 
 
-@router.get("/user/{user_id}/stats", response_model=SRReviewStatsResponse)
+@router.get("/user/me/stats", response_model=SRReviewStatsResponse)
 def get_user_review_stats(
-    user_id: UUID, 
+    request: Request,
     service: SRReviewService = Depends(get_sr_review_service)
 ) -> SRReviewStatsResponse:
+    user_id: UUID = request.state.user_id
     stats = service.get_user_review_stats(user_id)
     return SRReviewStatsResponse(**stats)
 

--- a/lesson-services/app/routers/user_streak_routes.py
+++ b/lesson-services/app/routers/user_streak_routes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy.orm import Session
 from typing import List, Optional
 from uuid import UUID
@@ -22,29 +22,32 @@ def get_user_streak_service(db: Session = Depends(get_db)) -> UserStreakService:
     return UserStreakService(db)
 
 
-@router.get("/user/{user_id}", response_model=UserStreakResponse)
+@router.get("/user/me", response_model=UserStreakResponse)
 def get_user_streak(
-    user_id: UUID,
+    request: Request,
     service: UserStreakService = Depends(get_user_streak_service),
 ) -> UserStreakResponse:
+    user_id: UUID = request.state.user_id
     return service.get_or_create_streak(user_id)
 
 
-@router.post("/user/{user_id}/check", response_model=UserStreakResponse)
+@router.post("/user/me/check", response_model=UserStreakResponse)
 def check_user_streak(
-    user_id: UUID,
+    request: Request,
     payload: Optional[StreakCheckRequest] = None,
     service: UserStreakService = Depends(get_user_streak_service),
 ) -> UserStreakResponse:
+    user_id: UUID = request.state.user_id
     activity_date = payload.activity_date if payload else None
     return service.check_and_update_streak(user_id, activity_date=activity_date)
 
 
-@router.get("/user/{user_id}/status", response_model=UserStreakStatusResponse)
+@router.get("/user/me/status", response_model=UserStreakStatusResponse)
 def get_streak_status(
-    user_id: UUID,
+    request: Request,
     service: UserStreakService = Depends(get_user_streak_service),
 ) -> UserStreakStatusResponse:
+    user_id: UUID = request.state.user_id
     status_data = service.get_streak_status(user_id)
     return UserStreakStatusResponse(**status_data)
 


### PR DESCRIPTION
## Summary
- replace user-specific lesson service routes to read the authenticated user from the internal auth middleware
- update affected endpoints to expose `/user/me` style paths instead of requiring a `user_id` URL segment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ea10102370832a8d5b0e6e4d0afbae