### PR TITLE
Integrate lesson service daily activity and dim user APIs

### DIFF
--- a/bff-services/internal/api/controllers/index.go
+++ b/bff-services/internal/api/controllers/index.go
@@ -1,7 +1,4 @@
-package controllers	
-
-import (
-)
+package controllers
 
 // Controllers holds all initialized controllers
 type Controllers struct {
@@ -11,4 +8,5 @@ type Controllers struct {
 	Session      *SessionController
 	Content      *ContentController
 	Notification *NotificationController
+	Lesson       *LessonController
 }

--- a/bff-services/internal/api/controllers/lesson_controller.go
+++ b/bff-services/internal/api/controllers/lesson_controller.go
@@ -1,0 +1,251 @@
+package controllers
+
+import (
+	"net/http"
+
+	"bff-services/internal/api/dto"
+	middleware "bff-services/internal/middlewares"
+	"bff-services/internal/services"
+	"bff-services/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+type LessonController struct {
+	lessonService services.LessonService
+}
+
+func NewLessonController(lessonService services.LessonService) *LessonController {
+	return &LessonController{lessonService: lessonService}
+}
+
+func (l *LessonController) GetDailyActivityToday(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	resp, err := l.lessonService.GetDailyActivityToday(c.Request.Context(), token)
+	if err != nil {
+		utils.Fail(c, "Unable to fetch today's activity", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (l *LessonController) GetDailyActivityByDate(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	activityDate := c.Param("activity_date")
+	if activityDate == "" {
+		utils.Fail(c, "activity_date is required", http.StatusBadRequest, "missing activity date")
+		return
+	}
+
+	resp, err := l.lessonService.GetDailyActivityByDate(c.Request.Context(), token, activityDate)
+	if err != nil {
+		utils.Fail(c, "Unable to fetch activity", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (l *LessonController) GetDailyActivityRange(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	resp, err := l.lessonService.GetDailyActivityRange(
+		c.Request.Context(),
+		token,
+		c.Query("date_from"),
+		c.Query("date_to"),
+	)
+	if err != nil {
+		utils.Fail(c, "Unable to fetch activity range", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (l *LessonController) GetDailyActivityWeek(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	resp, err := l.lessonService.GetDailyActivityWeek(c.Request.Context(), token)
+	if err != nil {
+		utils.Fail(c, "Unable to fetch weekly activity", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (l *LessonController) GetDailyActivityMonth(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	resp, err := l.lessonService.GetDailyActivityMonth(
+		c.Request.Context(),
+		token,
+		c.Query("year"),
+		c.Query("month"),
+	)
+	if err != nil {
+		utils.Fail(c, "Unable to fetch monthly activity", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (l *LessonController) GetDailyActivitySummary(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	resp, err := l.lessonService.GetDailyActivitySummary(c.Request.Context(), token)
+	if err != nil {
+		utils.Fail(c, "Unable to fetch activity summary", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (l *LessonController) IncrementDailyActivity(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	var req dto.DailyActivityIncrementRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.Fail(c, "Invalid request payload", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := l.lessonService.IncrementDailyActivity(c.Request.Context(), token, req)
+	if err != nil {
+		utils.Fail(c, "Unable to update activity", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (l *LessonController) GetUserPreferences(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	resp, err := l.lessonService.GetUserPreferences(c.Request.Context(), token)
+	if err != nil {
+		utils.Fail(c, "Unable to fetch user preferences", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (l *LessonController) CreateUserPreferences(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	userID, _, _, ok := middleware.GetUserContextFromMiddleware(c)
+	if !ok {
+		return
+	}
+
+	var req dto.DimUserCreateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.Fail(c, "Invalid request payload", http.StatusBadRequest, err.Error())
+		return
+	}
+	req.UserID = userID
+
+	resp, err := l.lessonService.CreateUserPreferences(c.Request.Context(), token, req)
+	if err != nil {
+		utils.Fail(c, "Unable to create user preferences", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (l *LessonController) UpdateUserPreferences(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	var req dto.DimUserUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.Fail(c, "Invalid request payload", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if req.Locale == nil && req.LevelHint == nil {
+		utils.Fail(c, "At least one field must be provided", http.StatusBadRequest, "empty update payload")
+		return
+	}
+
+	resp, err := l.lessonService.UpdateUserPreferences(c.Request.Context(), token, req)
+	if err != nil {
+		utils.Fail(c, "Unable to update user preferences", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (l *LessonController) UpdateUserLocale(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	var req dto.DimUserLocaleUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.Fail(c, "Invalid request payload", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	resp, err := l.lessonService.UpdateUserLocale(c.Request.Context(), token, req)
+	if err != nil {
+		utils.Fail(c, "Unable to update user locale", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}
+
+func (l *LessonController) DeleteUserPreferences(c *gin.Context) {
+	token, ok := requireBearerToken(c)
+	if !ok {
+		return
+	}
+
+	resp, err := l.lessonService.DeleteUserPreferences(c.Request.Context(), token)
+	if err != nil {
+		utils.Fail(c, "Unable to delete user preferences", http.StatusBadGateway, err.Error())
+		return
+	}
+
+	respondWithServiceResponse(c, resp)
+}

--- a/bff-services/internal/api/dto/lesson_dto.go
+++ b/bff-services/internal/api/dto/lesson_dto.go
@@ -1,0 +1,26 @@
+package dto
+
+// DailyActivityIncrementRequest represents payload for incrementing a user's activity counters.
+type DailyActivityIncrementRequest struct {
+	ActivityDate *string `json:"activity_dt,omitempty"`
+	Field        string  `json:"field" binding:"required,oneof=lessons_completed quizzes_completed minutes points"`
+	Amount       int     `json:"amount" binding:"required,min=1"`
+}
+
+// DimUserCreateRequest mirrors the dim user creation payload expected by the lesson service.
+type DimUserCreateRequest struct {
+	UserID    string  `json:"user_id"`
+	Locale    *string `json:"locale,omitempty" binding:"omitempty,max=50"`
+	LevelHint *string `json:"level_hint,omitempty" binding:"omitempty,max=50"`
+}
+
+// DimUserUpdateRequest mirrors the partial update payload for dim user records.
+type DimUserUpdateRequest struct {
+	Locale    *string `json:"locale,omitempty" binding:"omitempty,max=50"`
+	LevelHint *string `json:"level_hint,omitempty" binding:"omitempty,max=50"`
+}
+
+// DimUserLocaleUpdateRequest represents the payload for locale-only updates.
+type DimUserLocaleUpdateRequest struct {
+	Locale string `json:"locale" binding:"required,max=50"`
+}

--- a/bff-services/internal/routes/lesson_routes.go
+++ b/bff-services/internal/routes/lesson_routes.go
@@ -1,0 +1,37 @@
+package routes
+
+import (
+	"bff-services/internal/api/controllers"
+	"bff-services/internal/cache"
+	middleware "bff-services/internal/middlewares"
+
+	"github.com/gin-gonic/gin"
+)
+
+func SetupLessonRoutes(api *gin.RouterGroup, controllers *controllers.Controllers, sessionCache *cache.SessionCache) {
+	if controllers.Lesson == nil || sessionCache == nil {
+		return
+	}
+
+	daily := api.Group("/daily-activity")
+	daily.Use(middleware.AuthRequired(sessionCache))
+	{
+		daily.GET("/user/me/today", controllers.Lesson.GetDailyActivityToday)
+		daily.GET("/user/me/date/:activity_date", controllers.Lesson.GetDailyActivityByDate)
+		daily.GET("/user/me/range", controllers.Lesson.GetDailyActivityRange)
+		daily.GET("/user/me/week", controllers.Lesson.GetDailyActivityWeek)
+		daily.GET("/user/me/month", controllers.Lesson.GetDailyActivityMonth)
+		daily.GET("/user/me/stats/summary", controllers.Lesson.GetDailyActivitySummary)
+		daily.POST("/increment", controllers.Lesson.IncrementDailyActivity)
+	}
+
+	dimUser := api.Group("/users")
+	dimUser.Use(middleware.AuthRequired(sessionCache))
+	{
+		dimUser.GET("/me", controllers.Lesson.GetUserPreferences)
+		dimUser.POST("", controllers.Lesson.CreateUserPreferences)
+		dimUser.PUT("/me", controllers.Lesson.UpdateUserPreferences)
+		dimUser.PATCH("/me/locale", controllers.Lesson.UpdateUserLocale)
+		dimUser.DELETE("/me", controllers.Lesson.DeleteUserPreferences)
+	}
+}

--- a/bff-services/internal/server/controllers.go
+++ b/bff-services/internal/server/controllers.go
@@ -29,5 +29,9 @@ func initControllers(deps Deps) *controllers.Controllers {
 		ctrl.Notification = controllers.NewNotificationController(deps.NotificationService)
 	}
 
+	if deps.LessonService != nil {
+		ctrl.Lesson = controllers.NewLessonController(deps.LessonService)
+	}
+
 	return ctrl
 }

--- a/bff-services/internal/server/router.go
+++ b/bff-services/internal/server/router.go
@@ -57,6 +57,7 @@ func setupAPIRoutes(r *gin.Engine, controllers *controllers.Controllers, session
 	routes.SetupMFARoutes(api, controllers)
 	routes.SetupSessionRoutes(api, controllers)
 	routes.SetupContentRoutes(api, controllers)
+	routes.SetupLessonRoutes(api, controllers, sessionCache)
 	routes.SetupUserRoutes(api, controllers, sessionCache)
 	routes.SetupNotificationRoutes(api, controllers)
 }

--- a/bff-services/internal/services/lesson_service.go
+++ b/bff-services/internal/services/lesson_service.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
+	"bff-services/internal/api/dto"
 	"bff-services/internal/types"
 )
 
@@ -17,6 +19,18 @@ import (
 type LessonService interface {
 	GetUserPoints(ctx context.Context, userID string) (*types.HTTPResponse, error)
 	GetUserStreak(ctx context.Context, userID string) (*types.HTTPResponse, error)
+	GetDailyActivityToday(ctx context.Context, token string) (*types.HTTPResponse, error)
+	GetDailyActivityByDate(ctx context.Context, token, activityDate string) (*types.HTTPResponse, error)
+	GetDailyActivityRange(ctx context.Context, token, dateFrom, dateTo string) (*types.HTTPResponse, error)
+	GetDailyActivityWeek(ctx context.Context, token string) (*types.HTTPResponse, error)
+	GetDailyActivityMonth(ctx context.Context, token, year, month string) (*types.HTTPResponse, error)
+	GetDailyActivitySummary(ctx context.Context, token string) (*types.HTTPResponse, error)
+	IncrementDailyActivity(ctx context.Context, token string, payload dto.DailyActivityIncrementRequest) (*types.HTTPResponse, error)
+	GetUserPreferences(ctx context.Context, token string) (*types.HTTPResponse, error)
+	CreateUserPreferences(ctx context.Context, token string, payload dto.DimUserCreateRequest) (*types.HTTPResponse, error)
+	UpdateUserPreferences(ctx context.Context, token string, payload dto.DimUserUpdateRequest) (*types.HTTPResponse, error)
+	UpdateUserLocale(ctx context.Context, token string, payload dto.DimUserLocaleUpdateRequest) (*types.HTTPResponse, error)
+	DeleteUserPreferences(ctx context.Context, token string) (*types.HTTPResponse, error)
 }
 
 // LessonServiceClient implements LessonService against a remote HTTP REST endpoint.
@@ -51,6 +65,80 @@ func (c *LessonServiceClient) GetUserStreak(ctx context.Context, userID string) 
 	}
 	path := "/api/streaks/user/" + userID
 	return c.doRequest(ctx, http.MethodGet, path, nil, nil)
+}
+
+func (c *LessonServiceClient) GetDailyActivityToday(ctx context.Context, token string) (*types.HTTPResponse, error) {
+	return c.doRequest(ctx, http.MethodGet, "/api/daily-activity/user/me/today", nil, authHeader(token))
+}
+
+func (c *LessonServiceClient) GetDailyActivityByDate(ctx context.Context, token, activityDate string) (*types.HTTPResponse, error) {
+	if activityDate == "" {
+		return nil, fmt.Errorf("activity date is required")
+	}
+	path := "/api/daily-activity/user/me/date/" + activityDate
+	return c.doRequest(ctx, http.MethodGet, path, nil, authHeader(token))
+}
+
+func (c *LessonServiceClient) GetDailyActivityRange(ctx context.Context, token, dateFrom, dateTo string) (*types.HTTPResponse, error) {
+	path := "/api/daily-activity/user/me/range"
+	query := url.Values{}
+	if dateFrom != "" {
+		query.Add("date_from", dateFrom)
+	}
+	if dateTo != "" {
+		query.Add("date_to", dateTo)
+	}
+	if len(query) > 0 {
+		path += "?" + query.Encode()
+	}
+	return c.doRequest(ctx, http.MethodGet, path, nil, authHeader(token))
+}
+
+func (c *LessonServiceClient) GetDailyActivityWeek(ctx context.Context, token string) (*types.HTTPResponse, error) {
+	return c.doRequest(ctx, http.MethodGet, "/api/daily-activity/user/me/week", nil, authHeader(token))
+}
+
+func (c *LessonServiceClient) GetDailyActivityMonth(ctx context.Context, token, year, month string) (*types.HTTPResponse, error) {
+	path := "/api/daily-activity/user/me/month"
+	query := url.Values{}
+	if year != "" {
+		query.Add("year", year)
+	}
+	if month != "" {
+		query.Add("month", month)
+	}
+	if len(query) > 0 {
+		path += "?" + query.Encode()
+	}
+	return c.doRequest(ctx, http.MethodGet, path, nil, authHeader(token))
+}
+
+func (c *LessonServiceClient) GetDailyActivitySummary(ctx context.Context, token string) (*types.HTTPResponse, error) {
+	return c.doRequest(ctx, http.MethodGet, "/api/daily-activity/user/me/stats/summary", nil, authHeader(token))
+}
+
+func (c *LessonServiceClient) IncrementDailyActivity(ctx context.Context, token string, payload dto.DailyActivityIncrementRequest) (*types.HTTPResponse, error) {
+	return c.doRequest(ctx, http.MethodPost, "/api/daily-activity/increment", payload, authHeader(token))
+}
+
+func (c *LessonServiceClient) GetUserPreferences(ctx context.Context, token string) (*types.HTTPResponse, error) {
+	return c.doRequest(ctx, http.MethodGet, "/api/users/me", nil, authHeader(token))
+}
+
+func (c *LessonServiceClient) CreateUserPreferences(ctx context.Context, token string, payload dto.DimUserCreateRequest) (*types.HTTPResponse, error) {
+	return c.doRequest(ctx, http.MethodPost, "/api/users", payload, authHeader(token))
+}
+
+func (c *LessonServiceClient) UpdateUserPreferences(ctx context.Context, token string, payload dto.DimUserUpdateRequest) (*types.HTTPResponse, error) {
+	return c.doRequest(ctx, http.MethodPut, "/api/users/me", payload, authHeader(token))
+}
+
+func (c *LessonServiceClient) UpdateUserLocale(ctx context.Context, token string, payload dto.DimUserLocaleUpdateRequest) (*types.HTTPResponse, error) {
+	return c.doRequest(ctx, http.MethodPatch, "/api/users/me/locale", payload, authHeader(token))
+}
+
+func (c *LessonServiceClient) DeleteUserPreferences(ctx context.Context, token string) (*types.HTTPResponse, error) {
+	return c.doRequest(ctx, http.MethodDelete, "/api/users/me", nil, authHeader(token))
 }
 
 func (c *LessonServiceClient) doRequest(ctx context.Context, method, path string, payload interface{}, headers http.Header) (*types.HTTPResponse, error) {
@@ -99,4 +187,13 @@ func (c *LessonServiceClient) doRequest(ctx context.Context, method, path string
 		Body:       respBody,
 		Headers:    resp.Header.Clone(),
 	}, nil
+}
+
+func authHeader(token string) http.Header {
+	if strings.TrimSpace(token) == "" {
+		return nil
+	}
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+strings.TrimSpace(token))
+	return header
 }


### PR DESCRIPTION
## Summary
- extend the lesson service client with daily activity and dim user endpoints plus request DTOs
- add a dedicated lesson controller and routes so the BFF can proxy daily activity and user preference APIs

## Testing
- go test ./... *(hangs while resolving modules; aborted)*


------
https://chatgpt.com/codex/tasks/task_b_68f07302748c832ab625059953c67546